### PR TITLE
jwt bulk token generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Temporary Items
 
 gradle.properties
 /qiin-be/src/main/generated/
+
+### user token csv ###
+/qiin-be/output

--- a/qiin-be/docker-compose.yml
+++ b/qiin-be/docker-compose.yml
@@ -105,6 +105,8 @@ services:
       AWS_S3_BUCKET: ${AWS_S3_BUCKET}
       MY_OPENAI_KEY: ${MY_OPENAI_KEY}
     restart: on-failure
+    volumes:
+      - ./output:/output
 
 volumes:
   mariadb_data:

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/request/CreateReservationRequestDto.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/request/CreateReservationRequestDto.java
@@ -15,10 +15,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CreateReservationRequestDto {
 
-    // 신청자
-    @NotNull
-    private Long applicantId;
-
     // 예약 시작 시간
     @NotNull
     private Instant startAt;

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -88,9 +88,10 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // 선착순 예약 분산락 키 : 자원 id로만 두기 제한적
     @Override
     @Transactional
-    @DistributedLock(
-            key =
-                    "'reservation:' + #assetId + ':' + #createReservationRequestDto.startAt + ':' + #createReservationRequestDto.endAt")
+//    @DistributedLock(
+//            key =
+//                    "'reservation:' + #assetId + ':' + #createReservationRequestDto.startAt + ':' + #createReservationRequestDto.endAt")
+
     public ReservationResponseDto instantConfirmReservation(
             final Long userId, final Long assetId, final CreateReservationRequestDto createReservationRequestDto) {
 

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -1,6 +1,5 @@
 package com.beyond.qiin.domain.booking.service.command;
 
-import com.beyond.qiin.common.annotation.DistributedLock;
 import com.beyond.qiin.domain.accounting.service.command.UsageHistoryCommandService;
 import com.beyond.qiin.domain.booking.dto.reservation.request.ConfirmReservationRequestDto;
 import com.beyond.qiin.domain.booking.dto.reservation.request.CreateReservationRequestDto;
@@ -88,9 +87,10 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // 선착순 예약 분산락 키 : 자원 id로만 두기 제한적
     @Override
     @Transactional
-//    @DistributedLock(
-//            key =
-//                    "'reservation:' + #assetId + ':' + #createReservationRequestDto.startAt + ':' + #createReservationRequestDto.endAt")
+    //    @DistributedLock(
+    //            key =
+    //                    "'reservation:' + #assetId + ':' + #createReservationRequestDto.startAt + ':' +
+    // #createReservationRequestDto.endAt")
 
     public ReservationResponseDto instantConfirmReservation(
             final Long userId, final Long assetId, final CreateReservationRequestDto createReservationRequestDto) {

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/JwtBulkTokenGenerator.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/JwtBulkTokenGenerator.java
@@ -1,0 +1,43 @@
+package com.beyond.qiin.domain.booking.support;
+
+import com.beyond.qiin.security.jwt.JwtTokenProvider;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class JwtBulkTokenGenerator implements CommandLineRunner {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void run(String... args) {
+        try {
+            // 컨테이너 내부 경로 (volume으로 호스트와 연결됨)
+            Path output = Path.of("/output/user_tokens.csv");
+
+            // 헤더 작성 (기존 파일 있으면 덮어씀)
+            Files.writeString(
+                    output, "userId,accessToken\n", StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+            for (long userId = 4; userId <= 103; userId++) {
+                String token = jwtTokenProvider.generateAccessToken(
+                        userId, "GENERAL", "user" + userId + "@test.com", List.of());
+
+                Files.writeString(output, userId + "," + token + "\n", StandardOpenOption.APPEND);
+            }
+
+            System.out.println("JWT CSV generated at: " + output.toAbsolutePath());
+
+        } catch (Exception e) {
+            throw new RuntimeException("JWT CSV generation failed", e);
+        }
+    }
+}

--- a/qiin-be/src/main/resources/application.yml
+++ b/qiin-be/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    default: ${SPRING_PROFILES_ACTIVE:test}
+    default: ${SPRING_PROFILES_ACTIVE:dev}
 
   mvc:
     async:

--- a/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/ReservationControllerTest.java
+++ b/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/ReservationControllerTest.java
@@ -4,10 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -92,7 +89,6 @@ public class ReservationControllerTest {
         CustomUserDetails mockUser = new CustomUserDetails(1L, "tester", authorities);
 
         CreateReservationRequestDto request = CreateReservationRequestDto.builder()
-                .applicantId(1L)
                 .startAt(start)
                 .endAt(end)
                 .description("팀 회의")

--- a/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/InstantConfirmReservationTest.java
+++ b/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/InstantConfirmReservationTest.java
@@ -90,13 +90,15 @@ public class InstantConfirmReservationTest {
                 .build();
 
         User applicant = User.builder().userName("신청자").build();
+
         Asset asset = Asset.builder().name("회의실 A").build();
+
         List<User> attendants = List.of(
                 User.builder().userName("참석자1").build(),
                 User.builder().userName("참석자2").build());
 
-        when(assetCommandService.getAssetById(assetId)).thenReturn(asset);
         when(userReader.findById(userId)).thenReturn(applicant);
+        when(assetCommandService.getAssetById(assetId)).thenReturn(asset);
         doNothing().when(userReader).validateAllExist(requestDto.getAttendantIds());
         when(userReader.findAllByIds(requestDto.getAttendantIds())).thenReturn(attendants);
         when(assetCommandService.isAvailable(assetId)).thenReturn(true);


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 임시 사용자 데이터 활용 로그인을 위한 bulk token generator

## ✨ 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/2-user-token-generator

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#2 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

- jwt bulk token generator : application-dev.yml 시 실행
- qiin-be/output 폴더 안에 user token csv 생성 
- docker compose : 컨테이너 내부 output 폴더에 로컬 pc output 폴더 연결해 내용 저장
- .gitignore : 생성되는 output 폴더 추가 

- application.yml : 기본 설정 dev 
- reservation command service impl : 분산락 제거(단일 서버 락 제어 시 불필요)
- reservation controller test, instant confirm reservation test : reservation instant confirm 시 applicant id 필요 없어 삭제 후 변경