### PR TITLE
자원 조회 시 pessimistic lock 추가

### DIFF
--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -95,7 +95,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     public ReservationResponseDto instantConfirmReservation(
             final Long userId, final Long assetId, final CreateReservationRequestDto createReservationRequestDto) {
 
-        Asset asset = assetCommandService.findByIdWithLock(assetId); //자원에 대한 비관적 락 획득
+        Asset asset = assetCommandService.findByIdWithLock(assetId); // 자원에 대한 비관적 락 획득
         User applicant = userReader.findById(userId);
         userReader.validateAllExist(createReservationRequestDto.getAttendantIds()); // 참여자 목록의 사용자들이 모두 존재하는지에 대한 확인
         List<User> attendantUsers = userReader.findAllByIds(createReservationRequestDto.getAttendantIds());

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -95,7 +95,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     public ReservationResponseDto instantConfirmReservation(
             final Long userId, final Long assetId, final CreateReservationRequestDto createReservationRequestDto) {
 
-        Asset asset = assetCommandService.getAssetById(assetId);
+        Asset asset = assetCommandService.findByIdWithLock(assetId); //자원에 대한 비관적 락 획득
         User applicant = userReader.findById(userId);
         userReader.validateAllExist(createReservationRequestDto.getAttendantIds()); // 참여자 목록의 사용자들이 모두 존재하는지에 대한 확인
         List<User> attendantUsers = userReader.findAllByIds(createReservationRequestDto.getAttendantIds());

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/repository/AssetJpaRepository.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/repository/AssetJpaRepository.java
@@ -1,9 +1,8 @@
 package com.beyond.qiin.domain.inventory.repository;
 
 import com.beyond.qiin.domain.inventory.entity.Asset;
-import java.util.Optional;
-
 import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/repository/AssetJpaRepository.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/repository/AssetJpaRepository.java
@@ -2,7 +2,11 @@ package com.beyond.qiin.domain.inventory.repository;
 
 import com.beyond.qiin.domain.inventory.entity.Asset;
 import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +20,8 @@ public interface AssetJpaRepository extends JpaRepository<Asset, Long> {
     boolean existsByCategoryId(Long categoryId);
 
     boolean existsByNameAndIdNot(String name, Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Asset a where a.id = :assetId")
+    Optional<Asset> findByIdForUpdate(Long assetId);
 }

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandService.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandService.java
@@ -29,6 +29,6 @@ public interface AssetCommandService {
     // 자원 사용 가능 여부
     boolean isAvailable(Long assetId);
 
-    //자원별 비관적 락 부여 조회 (예약의 범위 겹침에 대한 동시 접근 차단)
+    // 자원별 비관적 락 부여 조회 (예약의 범위 겹침에 대한 동시 접근 차단)
     Asset findByIdWithLock(Long assetId);
 }

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandService.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandService.java
@@ -28,4 +28,7 @@ public interface AssetCommandService {
 
     // 자원 사용 가능 여부
     boolean isAvailable(Long assetId);
+
+    //자원별 비관적 락 부여 조회 (예약의 범위 겹침에 대한 동시 접근 차단)
+    Asset findByIdWithLock(Long assetId);
 }

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandServiceImpl.java
@@ -300,10 +300,9 @@ public class AssetCommandServiceImpl implements AssetCommandService {
         return true;
     }
 
-    //비관적 락을 통한 조회 - 예약 시 겹침 확인에 대한 동시 접근 차단
+    // 비관적 락을 통한 조회 - 예약 시 겹침 확인에 대한 동시 접근 차단
     @Transactional
     public Asset findByIdWithLock(Long assetId) {
-        return assetJpaRepository.findByIdForUpdate(assetId)
-                .orElseThrow(AssetException::notFound);
+        return assetJpaRepository.findByIdForUpdate(assetId).orElseThrow(AssetException::notFound);
     }
 }

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/inventory/service/command/AssetCommandServiceImpl.java
@@ -299,4 +299,11 @@ public class AssetCommandServiceImpl implements AssetCommandService {
         }
         return true;
     }
+
+    //비관적 락을 통한 조회 - 예약 시 겹침 확인에 대한 동시 접근 차단
+    @Transactional
+    public Asset findByIdWithLock(Long assetId) {
+        return assetJpaRepository.findByIdForUpdate(assetId)
+                .orElseThrow(AssetException::notFound);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 동시 예약 시 겹치는 시간대 중복 문제 해결용 자원 조회에 대한 pessimistic lock 추가 

## ✨ 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [X] 코드 리팩토링
- [ ] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/10-reservation-pessimistic-lock

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#10 ]
- Closes [#9 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- 특정 자원의 예약된 시간대 조회 시 비관적 락을 거는 것에 대한 고려를 했으나 특정 시간대의 로우가 없을 때 동시에 서로 맞물리는 예약이 들어오게 되면 락을 걸 수 없게 됨에 따라 해당 시점에는 데이터 정합성을 보장하기 어려운 문제를 발견함
- 이에 따라 자원 조회 시 비관적 락을 획득하도록 수정
- 따라서 예약하기 요청 시 자원 조회를 통한 비관적 락 획득 후 트랜잭션 전파로 인해 해당 예약하기 커밋까지 락 획득이 유지되어 다른 요청이 진행될 수 없음
- 이를 바탕으로 시간대 겹침에 대한 검증을 완전하게 적용 가능을 확인