### PR TITLE
신청예약목록 조회시 레디스 캐시 추가

### DIFF
--- a/qiin-be/build.gradle
+++ b/qiin-be/build.gradle
@@ -72,6 +72,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     //redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.20.0'

--- a/qiin-be/docker-compose.staging.yml
+++ b/qiin-be/docker-compose.staging.yml
@@ -5,6 +5,12 @@ services:
     restart: always
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.0
@@ -28,6 +34,12 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    healthcheck:
+      test: [ "CMD-SHELL", "kafka-topics --bootstrap-server localhost:9092 --list > /dev/null 2>&1" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
 
   backend:
     build: .

--- a/qiin-be/docker-compose.yml
+++ b/qiin-be/docker-compose.yml
@@ -28,6 +28,12 @@ services:
     restart: unless-stopped
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.0
@@ -59,6 +65,12 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
     tmpfs: #임시 볼륨, 개발용
         - /var/lib/kafka/data:rw,uid=1000,gid=1000
+    healthcheck:
+      test: [ "CMD-SHELL", "kafka-topics --bootstrap-server localhost:9092 --list > /dev/null 2>&1" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest

--- a/qiin-be/src/main/java/com/beyond/qiin/QiinApplication.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/QiinApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties
 @ConfigurationPropertiesScan
 @EnableScheduling
+@EnableCaching
 public class QiinApplication {
 
     public static void main(String[] args) {

--- a/qiin-be/src/main/java/com/beyond/qiin/common/dto/PageResponseDto.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/common/dto/PageResponseDto.java
@@ -6,11 +6,13 @@ import java.util.stream.StreamSupport;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor // 레디스가 json으로 받아 직렬화했던 정보를 역직렬화 해 제공 시 자바 객체로 생성하기 위함
 public class PageResponseDto<T> {
 
     private int page; // 현재 페이지 (0부터 시작)

--- a/qiin-be/src/main/java/com/beyond/qiin/config/JpaRepositoryConfig.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/config/JpaRepositoryConfig.java
@@ -1,0 +1,8 @@
+package com.beyond.qiin.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.beyond.qiin.domain")
+public class JpaRepositoryConfig {}

--- a/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
@@ -1,5 +1,8 @@
 package com.beyond.qiin.config;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -10,10 +13,6 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-
 @Configuration
 public class RedisCacheConfig {
 
@@ -21,25 +20,26 @@ public class RedisCacheConfig {
     public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
         RedisSerializer<String> keySerializer = new StringRedisSerializer();
 
-        //value는 list, dto 등 다양한 type 가능하므로 Object
-        RedisSerializer<Object> valueSerializer = new GenericJackson2JsonRedisSerializer(); //객체를 json으로 바꾸고 class 정보 저장
+        // value는 list, dto 등 다양한 type 가능하므로 Object
+        RedisSerializer<Object> valueSerializer =
+                new GenericJackson2JsonRedisSerializer(); // 객체를 json으로 바꾸고 class 정보 저장
 
         // 공통 config 설정
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer))
                 .disableCachingNullValues()
-                .entryTtl(Duration.ofMinutes(5)); //기본 5분
+                .entryTtl(Duration.ofMinutes(5)); // 기본 5분
 
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 
         // 신청 예약 목록 조회용 캐시
-        cacheConfigurations.put("appliedReservations", defaultConfig.entryTtl(Duration.ofSeconds(15)));
+        cacheConfigurations.put("appliedReservations", defaultConfig.entryTtl(Duration.ofSeconds(60))); //1분 ttl 
 
         return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(defaultConfig) //default config 추가
-                .withInitialCacheConfigurations(cacheConfigurations) //신청 예약 목록용 캐시 추가
-                .transactionAware() //트랜잭션 커밋 성공 후 캐시에 반영
+                .cacheDefaults(defaultConfig) // default config 추가
+                .withInitialCacheConfigurations(cacheConfigurations) // 신청 예약 목록용 캐시 추가
+                .transactionAware() // 트랜잭션 커밋 성공 후 캐시에 반영
                 .build();
     }
 }

--- a/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
@@ -34,7 +34,7 @@ public class RedisCacheConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 
         // 신청 예약 목록 조회용 캐시
-        cacheConfigurations.put("appliedReservations", defaultConfig.entryTtl(Duration.ofSeconds(60))); //1분 ttl 
+        cacheConfigurations.put("appliedReservations", defaultConfig.entryTtl(Duration.ofMinutes(1))); // 1분 ttl
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig) // default config 추가

--- a/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/config/RedisCacheConfig.java
@@ -1,0 +1,45 @@
+package com.beyond.qiin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisSerializer<String> keySerializer = new StringRedisSerializer();
+
+        //value는 list, dto 등 다양한 type 가능하므로 Object
+        RedisSerializer<Object> valueSerializer = new GenericJackson2JsonRedisSerializer(); //객체를 json으로 바꾸고 class 정보 저장
+
+        // 공통 config 설정
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer))
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(5)); //기본 5분
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        // 신청 예약 목록 조회용 캐시
+        cacheConfigurations.put("appliedReservations", defaultConfig.entryTtl(Duration.ofSeconds(15)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig) //default config 추가
+                .withInitialCacheConfigurations(cacheConfigurations) //신청 예약 목록용 캐시 추가
+                .transactionAware() //트랜잭션 커밋 성공 후 캐시에 반영
+                .build();
+    }
+}

--- a/qiin-be/src/main/java/com/beyond/qiin/config/RedisRepositoryConfig.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/config/RedisRepositoryConfig.java
@@ -1,0 +1,8 @@
+package com.beyond.qiin.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(basePackages = "com.beyond.qiin.infra.redis")
+public class RedisRepositoryConfig {}

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/controller/ReservationController.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/controller/ReservationController.java
@@ -27,16 +27,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/reservations")
 @RestController
@@ -222,9 +213,9 @@ public class ReservationController {
 
         final Long userId = jwtTokenProvider.getUserId(accessToken);
 
-        PageResponseDto<GetAppliedReservationResponseDto> page =
+        PageResponseDto<GetAppliedReservationResponseDto> reservations =
                 reservationQueryService.getReservationApplies(userId, condition, pageable);
-        return ResponseEntity.ok(page);
+        return ResponseEntity.ok(reservations);
     }
 
     // 예약 가능 자원 목록 조회

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/applied_reservation/GetAppliedReservationResponseDto.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/applied_reservation/GetAppliedReservationResponseDto.java
@@ -2,14 +2,13 @@ package com.beyond.qiin.domain.booking.dto.reservation.response.applied_reservat
 
 import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawAppliedReservationResponseDto;
 import com.beyond.qiin.domain.booking.enums.ReservationStatus;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
 
 // 관리자 승인 / 거절
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Jacksonized
 @Getter
 public class GetAppliedReservationResponseDto {
 
@@ -23,7 +22,7 @@ public class GetAppliedReservationResponseDto {
     private final String applicantName;
 
     // 예약 가능 여부
-    private final boolean isReservable;
+    private final boolean reservable; // jacksonized에서 파악용 필드
 
     // 응답 시 필수 x
     // 승인자
@@ -49,7 +48,7 @@ public class GetAppliedReservationResponseDto {
                 .reservationStatus(
                         ReservationStatus.from(raw.getReservationStatus()).name())
                 .isApproved(raw.getIsApproved())
-                .isReservable(isReservable)
+                .reservable(isReservable)
                 .version(raw.getVersion())
                 .reason(raw.getReason())
                 .build();

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +53,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     // 승인 예약
     @Override
     @Transactional
+    @CacheEvict(cacheNames = "appliedReservations", key = "@appliedReservationCachePolicy.defaultKey()")
     public ReservationResponseDto applyReservation(
             final Long userId, final Long assetId, final CreateReservationRequestDto createReservationRequestDto) {
 
@@ -136,6 +138,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         return ReservationResponseDto.fromEntity(reservation);
     }
 
+    // key 의 appliedReservations prefix 바탕으로 해당 시 삭제 및 default key를 통해 생성
+    @CacheEvict(cacheNames = "appliedReservations", key = "@appliedReservationCachePolicy.defaultKey()")
     @Override
     @Transactional
     public ReservationResponseDto approveReservation(
@@ -170,6 +174,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         return ReservationResponseDto.fromEntity(reservation);
     }
 
+    @CacheEvict(cacheNames = "appliedReservations", key = "@appliedReservationCachePolicy.defaultKey()")
     @Override
     @Transactional
     public ReservationResponseDto rejectReservation(

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -94,6 +95,13 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     }
 
     // 신청 예약 목록 조회
+    @Cacheable(
+            cacheNames = "appliedReservations", // key prefix로 추가해 해당 캐시용으로 구별 용도
+            key = "@appliedReservationCachePolicy.defaultKey()", //조건으로 확인했으므로 키 생성시는 condition, pageable 생략 (default와 동일 키이기 때문
+            condition = "@appliedReservationCachePolicy.isCacheable(#condition, #pageable)", // 캐시 적용 여부의 조건
+            sync = true // 동시 요청으로 인해 다수 cache miss 발생 가능
+            // 따라서 캐시가 비어있는 경우는 1 요청 캐시 생성 후 나머지 요청의 캐시 사용 적용(전부 cache miss로 적용 x이도록)
+            )
     @Override
     @Transactional(readOnly = true)
     public PageResponseDto<GetAppliedReservationResponseDto> getReservationApplies(
@@ -112,6 +120,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         Page<RawAppliedReservationResponseDto> rawPage =
                 appliedReservationsQueryRepository.search(appliedReservationSearchCriteria, pageable);
 
+        //예약 가능한지에 대해 포함해서 페이지 제공
         Page<GetAppliedReservationResponseDto> page = rawPage.map(raw -> {
             boolean isAssetAvailable = assetQueryService.isAvailable(raw.getAssetId());
 

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
@@ -97,7 +97,8 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     // 신청 예약 목록 조회
     @Cacheable(
             cacheNames = "appliedReservations", // key prefix로 추가해 해당 캐시용으로 구별 용도
-            key = "@appliedReservationCachePolicy.defaultKey()", //조건으로 확인했으므로 키 생성시는 condition, pageable 생략 (default와 동일 키이기 때문
+            key = "@appliedReservationCachePolicy.defaultKey()", // 조건으로 확인했으므로 키 생성시는 condition, pageable 생략
+            // (default와 동일 키이기 때문)
             condition = "@appliedReservationCachePolicy.isCacheable(#condition, #pageable)", // 캐시 적용 여부의 조건
             sync = true // 동시 요청으로 인해 다수 cache miss 발생 가능
             // 따라서 캐시가 비어있는 경우는 1 요청 캐시 생성 후 나머지 요청의 캐시 사용 적용(전부 cache miss로 적용 x이도록)
@@ -120,7 +121,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         Page<RawAppliedReservationResponseDto> rawPage =
                 appliedReservationsQueryRepository.search(appliedReservationSearchCriteria, pageable);
 
-        //예약 가능한지에 대해 포함해서 페이지 제공
+        // 예약 가능한지에 대해 포함해서 페이지 제공
         Page<GetAppliedReservationResponseDto> page = rawPage.map(raw -> {
             boolean isAssetAvailable = assetQueryService.isAvailable(raw.getAssetId());
 

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/AppliedReservationCachePolicy.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/AppliedReservationCachePolicy.java
@@ -1,0 +1,100 @@
+package com.beyond.qiin.domain.booking.support;
+
+import com.beyond.qiin.domain.booking.dto.reservation.request.search_condition.GetAppliedReservationSearchCondition;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component("appliedReservationCachePolicy")
+@RequiredArgsConstructor
+public class AppliedReservationCachePolicy {
+    public boolean isCacheable(final GetAppliedReservationSearchCondition condition, final Pageable pageable) {
+        return hasNoKeyword(condition)
+                && isFirstPage(pageable)
+                && isPending(condition)
+                && isDefaultMonthlyRange(condition)
+                && isDefaultSort(pageable);
+    }
+
+    public String key(final GetAppliedReservationSearchCondition condition, final Pageable pageable) {
+        return String.format(
+                "status=pending:month=%s:sort=%s:size=%d",
+                resolveDefaultMonthToken(condition), //해당 달 기준의 키 생성
+                normalizeSort(pageable),
+                pageable.getPageSize());
+    }
+
+    //검색어　활용　ｘ
+    private boolean hasNoKeyword(final GetAppliedReservationSearchCondition condition) {
+        return isBlank(condition.getApplicantName()) && isBlank(condition.getAssetName());
+    }
+
+    //첫　페이지인지　확인
+    private boolean isFirstPage(final Pageable pageable) {
+        return pageable.getPageNumber() == 0;
+    }
+
+    //대기　상태　요청인지　확인
+    private boolean isPending(final GetAppliedReservationSearchCondition condition) {
+        return "PENDING".equalsIgnoreCase(condition.getReservationStatus());
+    }
+
+    //최근　한달에　대한　요청인지에　대해　확인용
+    private boolean isDefaultMonthlyRange(final GetAppliedReservationSearchCondition condition) {
+        LocalDate startDate = condition.getStartDate();
+        LocalDate endDate = condition.getEndDate();
+
+        if (startDate == null && endDate == null) {
+            return true;
+        }
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate defaultEnd = today.plusMonths(1);
+
+        return today.equals(startDate) && defaultEnd.equals(endDate);
+    }
+
+    
+    private String resolveDefaultMonthToken(final GetAppliedReservationSearchCondition condition) {
+        LocalDate baseDate = condition.getStartDate() != null ? condition.getStartDate() : LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        return YearMonth.from(baseDate).toString(); //날짜까지 포함하지 않고 달까지만 키로 추가
+    }
+
+    private boolean isDefaultSort(final Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) { //정렬 파라미터를 안넘긴 경우 query의 정렬이 desc일 때 보장
+            return true;
+        }
+
+        if (pageable.getSort().stream().count() != 1) { //sort 조건 하나여야함
+            return false;
+        }
+
+        Sort.Order createdAtDesc = pageable.getSort().getOrderFor("createdAt"); //createdAt에 해당하는 정렬 조건을 담음
+        return createdAtDesc != null && createdAtDesc.isDescending(); //createdAt 정렬이 존재하고 desc 기준인지 확인 (null인지 확인 x시 npe)
+    }
+
+    private String normalizeSort(final Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return "createdAt,desc";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Sort.Order order : pageable.getSort()) {
+            sb.append(order.getProperty())
+                    .append(",")
+                    .append(order.getDirection().name().toLowerCase());
+        }
+        return sb.toString();
+    }
+
+    //값이　비었는지　확인　：　검색어　활용했는지　확인용
+    private boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/AppliedReservationCachePolicy.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/support/AppliedReservationCachePolicy.java
@@ -4,7 +4,6 @@ import com.beyond.qiin.domain.booking.dto.reservation.request.search_condition.G
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.ZoneId;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -18,33 +17,40 @@ public class AppliedReservationCachePolicy {
                 && isFirstPage(pageable)
                 && isPending(condition)
                 && isDefaultMonthlyRange(condition)
-                && isDefaultSort(pageable);
+                && isDefaultSort(pageable)
+                && isDefaultPageSize(pageable);
     }
 
-    public String key(final GetAppliedReservationSearchCondition condition, final Pageable pageable) {
+    // evict 시에는 condition, pageable을 받지 않기 때문에
+    public String defaultKey() {
         return String.format(
                 "status=pending:month=%s:sort=%s:size=%d",
-                resolveDefaultMonthToken(condition), //해당 달 기준의 키 생성
-                normalizeSort(pageable),
-                pageable.getPageSize());
+                YearMonth.from(LocalDate.now(ZoneId.of("Asia/Seoul"))), // 달까지 포함하면 됨
+                "createdAt,desc",
+                20);
     }
 
-    //검색어　활용　ｘ
+    // size 20인지 확인
+    private boolean isDefaultPageSize(final Pageable pageable) {
+        return pageable.getPageSize() == 20;
+    }
+
+    // 검색어　활용　ｘ
     private boolean hasNoKeyword(final GetAppliedReservationSearchCondition condition) {
         return isBlank(condition.getApplicantName()) && isBlank(condition.getAssetName());
     }
 
-    //첫　페이지인지　확인
+    // 첫　페이지인지　확인
     private boolean isFirstPage(final Pageable pageable) {
         return pageable.getPageNumber() == 0;
     }
 
-    //대기　상태　요청인지　확인
+    // 대기　상태　요청인지　확인
     private boolean isPending(final GetAppliedReservationSearchCondition condition) {
         return "PENDING".equalsIgnoreCase(condition.getReservationStatus());
     }
 
-    //최근　한달에　대한　요청인지에　대해　확인용
+    // 최근　한달에　대한　요청인지에　대해　확인용
     private boolean isDefaultMonthlyRange(final GetAppliedReservationSearchCondition condition) {
         LocalDate startDate = condition.getStartDate();
         LocalDate endDate = condition.getEndDate();
@@ -59,24 +65,25 @@ public class AppliedReservationCachePolicy {
         return today.equals(startDate) && defaultEnd.equals(endDate);
     }
 
-    
     private String resolveDefaultMonthToken(final GetAppliedReservationSearchCondition condition) {
-        LocalDate baseDate = condition.getStartDate() != null ? condition.getStartDate() : LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate baseDate =
+                condition.getStartDate() != null ? condition.getStartDate() : LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        return YearMonth.from(baseDate).toString(); //날짜까지 포함하지 않고 달까지만 키로 추가
+        return YearMonth.from(baseDate).toString(); // 날짜까지 포함하지 않고 달까지만 키로 추가
     }
 
     private boolean isDefaultSort(final Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) { //정렬 파라미터를 안넘긴 경우 query의 정렬이 desc일 때 보장
+        if (pageable.getSort().isUnsorted()) { // 정렬 파라미터를 안넘긴 경우 query의 정렬이 desc일 때 보장
             return true;
         }
 
-        if (pageable.getSort().stream().count() != 1) { //sort 조건 하나여야함
+        if (pageable.getSort().stream().count() != 1) { // sort 조건 하나여야함
             return false;
         }
 
-        Sort.Order createdAtDesc = pageable.getSort().getOrderFor("createdAt"); //createdAt에 해당하는 정렬 조건을 담음
-        return createdAtDesc != null && createdAtDesc.isDescending(); //createdAt 정렬이 존재하고 desc 기준인지 확인 (null인지 확인 x시 npe)
+        Sort.Order createdAtDesc = pageable.getSort().getOrderFor("createdAt"); // createdAt에 해당하는 정렬 조건을 담음
+        return createdAtDesc != null
+                && createdAtDesc.isDescending(); // createdAt 정렬이 존재하고 desc 기준인지 확인 (null인지 확인 x시 npe)
     }
 
     private String normalizeSort(final Pageable pageable) {
@@ -93,7 +100,7 @@ public class AppliedReservationCachePolicy {
         return sb.toString();
     }
 
-    //값이　비었는지　확인　：　검색어　활용했는지　확인용
+    // 값이　비었는지　확인　：　검색어　활용했는지　확인용
     private boolean isBlank(final String value) {
         return value == null || value.isBlank();
     }

--- a/qiin-be/src/main/resources/application-dev.yml
+++ b/qiin-be/src/main/resources/application-dev.yml
@@ -1,4 +1,7 @@
 spring:
+  cache:
+    type:
+      redis
   config:
     activate:
       on-profile: dev

--- a/qiin-be/src/main/resources/application-dev.yml
+++ b/qiin-be/src/main/resources/application-dev.yml
@@ -1,7 +1,7 @@
 spring:
   cache:
-    type:
-      redis
+    type: redis #none
+
   config:
     activate:
       on-profile: dev

--- a/qiin-be/src/main/resources/application-prod.yml
+++ b/qiin-be/src/main/resources/application-prod.yml
@@ -1,4 +1,7 @@
 spring:
+  cache:
+    type:
+      redis
   config:
     activate:
       on-profile: prod
@@ -45,10 +48,6 @@ spring:
     baseline-version: "0"
     locations:
       - classpath:db/migration  # 마이그레이션 파일 경로 설정
-
-  # Redis 캐시 완전 비활성화
-  cache:
-    type: none
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}

--- a/qiin-be/src/main/resources/application-staging.yml
+++ b/qiin-be/src/main/resources/application-staging.yml
@@ -1,5 +1,8 @@
 
 spring:
+  cache:
+    type:
+      redis
   config:
     activate:
       on-profile: staging

--- a/qiin-be/src/main/resources/application.yml
+++ b/qiin-be/src/main/resources/application.yml
@@ -61,3 +61,4 @@ cors:
 logging:
   level:
     org.springframework: INFO
+    com.domino.smerp: INFO

--- a/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/InstantConfirmReservationTest.java
+++ b/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/InstantConfirmReservationTest.java
@@ -12,8 +12,10 @@ import com.beyond.qiin.domain.booking.dto.reservation.request.CreateReservationR
 import com.beyond.qiin.domain.booking.dto.reservation.response.ReservationResponseDto;
 import com.beyond.qiin.domain.booking.event.ReservationEventPublisher;
 import com.beyond.qiin.domain.booking.repository.AttendantJpaRepository;
+import com.beyond.qiin.domain.booking.repository.ReservationSlotJpaRepository;
 import com.beyond.qiin.domain.booking.support.AttendantWriter;
 import com.beyond.qiin.domain.booking.support.ReservationReader;
+import com.beyond.qiin.domain.booking.support.ReservationSlotManager;
 import com.beyond.qiin.domain.booking.support.ReservationWriter;
 import com.beyond.qiin.domain.iam.entity.User;
 import com.beyond.qiin.domain.iam.support.user.UserReader;
@@ -56,6 +58,12 @@ public class InstantConfirmReservationTest {
     @Mock
     private UsageHistoryCommandService usageHistoryCommandService;
 
+    @Mock
+    private ReservationSlotManager reservationSlotManager;
+
+    @Mock
+    private ReservationSlotJpaRepository reservationSlotJpaRepository;
+
     private Long userId;
     private Long assetId;
     private Instant startAt;
@@ -72,7 +80,9 @@ public class InstantConfirmReservationTest {
                 assetCommandService,
                 reservationEventPublisher,
                 attendantJpaRepository,
-                usageHistoryCommandService);
+                usageHistoryCommandService,
+                reservationSlotManager,
+                reservationSlotJpaRepository);
 
         userId = 1L;
         assetId = 100L;

--- a/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
+++ b/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
@@ -36,6 +36,8 @@ class ReservationTimeValidationTest {
 
     private boolean check(String start, String end, List<Reservation> existing) {
         when(reservationReader.getActiveReservationsByAssetId(1L)).thenReturn(existing);
+
+        // TODO :
         return reservationService.isReservationTimeAvailable(null, 1L, Instant.parse(start), Instant.parse(end));
     }
 

--- a/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsCacheTest.java
+++ b/qiin-be/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsCacheTest.java
@@ -1,0 +1,92 @@
+package com.beyond.qiin.domain.booking.service.query;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.beyond.qiin.common.dto.PageResponseDto;
+import com.beyond.qiin.domain.booking.dto.reservation.request.search_condition.GetAppliedReservationSearchCondition;
+import com.beyond.qiin.domain.booking.dto.reservation.response.applied_reservation.GetAppliedReservationResponseDto;
+import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawAppliedReservationResponseDto;
+import com.beyond.qiin.domain.booking.repository.querydsl.AppliedReservationsQueryRepository;
+import com.beyond.qiin.domain.iam.entity.User;
+import com.beyond.qiin.domain.iam.support.user.UserReader;
+import com.beyond.qiin.domain.inventory.service.query.AssetQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.*;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+public class GetAppliedReservationsCacheTest {
+
+    @Autowired
+    private ReservationQueryService reservationQueryService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @MockitoBean
+    private AppliedReservationsQueryRepository appliedReservationsQueryRepository;
+
+    @MockitoBean
+    private UserReader userReader;
+
+    @MockitoBean
+    private AssetQueryService assetQueryService;
+
+    @BeforeEach
+    void setUp() {
+        Cache cache = cacheManager.getCache("appliedReservations");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @DisplayName("같은 조건으로 2번 호출하면 두 번째는 캐시를 사용한다")
+    @Test
+    void getReservationApplies_should_use_cache_on_second_call() {
+        // given
+        Long userId = 1L;
+
+        GetAppliedReservationSearchCondition condition = new GetAppliedReservationSearchCondition();
+        condition.setReservationStatus("PENDING");
+        condition.setApplicantName(null);
+        condition.setAssetName(null);
+        condition.setCategoryId(null);
+        condition.setStartDate(null);
+        condition.setEndDate(null);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        User mockUser = mock(User.class);
+        given(userReader.findById(userId)).willReturn(mockUser);
+
+        RawAppliedReservationResponseDto rawDto = mock(RawAppliedReservationResponseDto.class);
+        given(rawDto.getAssetId()).willReturn(100L);
+        given(rawDto.getReservationId()).willReturn(200L);
+        given(rawDto.getStartAt()).willReturn(null);
+        given(rawDto.getEndAt()).willReturn(null);
+
+        Page<RawAppliedReservationResponseDto> rawPage = new PageImpl<>(java.util.List.of(rawDto), pageable, 1);
+
+        given(appliedReservationsQueryRepository.search(any(), any())).willReturn(rawPage);
+        given(assetQueryService.isAvailable(any())).willReturn(true);
+
+        // when
+        PageResponseDto<GetAppliedReservationResponseDto> first =
+                reservationQueryService.getReservationApplies(userId, condition, pageable);
+
+        PageResponseDto<GetAppliedReservationResponseDto> second =
+                reservationQueryService.getReservationApplies(userId, condition, pageable);
+
+        // then
+        verify(appliedReservationsQueryRepository, times(1)).search(any(), any());
+        verify(userReader, times(1)).findById(userId);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 신청예약목록 조회시 레디스 캐시 추가

## ✨ 변경 사항 (Changes)
- [X] 주요 기능 추가 / 변경
- [X] 코드 리팩토링
- [ ] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- refactor/29-cache

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#29 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- default cache config ttl : 5분, 신청예약목록조회 : 1분(jmeter 활용 테스트 시 30초 db 조회 있음에 따라 더 적절할 것으로 판단)
- 신청예약목록조회 첫페이지, 최근 한달, 예약 상태 대기인 경우에 대해 캐싱
- 승인, 거절을 다루는 페이지이므로 해당 변경 시 반영을 위해 캐시 무효화 (신청하기 또한 무효화 대상에 포함됨)
- 기본 조회 조건으로 캐싱하기 때문에 캐시 무효화 후 디폴트 캐싱 메서드도 요청에 의해 생성되는 경우와 동일
- 레디스 - json으로 받았던 정보의 역직렬화를 위해 기본생성자를 page response dto, get applied reservations dto 에 추가 
- redis repository config, jpa repository config 을 통한 repository 스캔 분리 및 jpa / redis 구현체 생성 
- Jacksonized : builder dto를 redis/jackson이 역직렬화 시 builder로 다시 객체를 만들 수 있게 해줌 
- 캐싱 적용 후 평균 응답시간은 395ms → 28ms, p95는 2573ms → 47ms로 약 50배 이상 개선 확인