### PR TITLE
Refactor/31 notification

### DIFF
--- a/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
@@ -21,8 +21,7 @@ public class SseController {
     private final JwtTokenProvider jwtTokenProvider;
     private final SseService sseService;
 
-    // SSE 구독
-    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+    // SSE 구독 - authorization header 사용 x(preauthorize : 권한 필요하지 않으므로 생략)
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@SseAccessToken String accessToken) {
 
@@ -31,8 +30,7 @@ public class SseController {
         return sseService.connect(userId);
     }
 
-    // SSE 구독 해제
-    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+    // SSE 구독 해제 - authorization header 사용 x(preauthorize : 권한 필요하지 않으므로 생략)
     @DeleteMapping("/unsubscribe")
     public void unsubscribe(@AccessToken final String accessToken) {
         final Long userId = jwtTokenProvider.getUserId(accessToken);

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
@@ -6,6 +6,7 @@ import com.beyond.qiin.security.resolver.AccessToken;
 import com.beyond.qiin.security.resolver.SseAccessToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +23,7 @@ public class SseController {
     private final SseService sseService;
 
     // SSE 구독
-    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+//    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@SseAccessToken String accessToken) {
 
@@ -32,7 +33,7 @@ public class SseController {
     }
 
     // SSE 구독 해제
-    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+//    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
     @DeleteMapping("/unsubscribe")
     public void unsubscribe(@AccessToken final String accessToken) {
         final Long userId = jwtTokenProvider.getUserId(accessToken);

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/controller/SseController.java
@@ -6,7 +6,6 @@ import com.beyond.qiin.security.resolver.AccessToken;
 import com.beyond.qiin.security.resolver.SseAccessToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +22,7 @@ public class SseController {
     private final SseService sseService;
 
     // SSE 구독
-//    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@SseAccessToken String accessToken) {
 
@@ -33,7 +32,7 @@ public class SseController {
     }
 
     // SSE 구독 해제
-//    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
+    //    @PreAuthorize("hasAnyAuthority('MASTER', 'ADMIN', 'MANAGER', 'GENERAL')")
     @DeleteMapping("/unsubscribe")
     public void unsubscribe(@AccessToken final String accessToken) {
         final Long userId = jwtTokenProvider.getUserId(accessToken);

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/entity/Notification.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/alarm/entity/Notification.java
@@ -72,7 +72,7 @@ public class Notification {
     @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
     private Instant createdAt;
 
-    @Column(name = "deleted_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP(6)")
     private Instant deletedAt;
 
     @PrePersist

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -159,7 +159,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         List<Long> attendantUserIds = reservation.getAttendants().stream()
                 .map(a -> a.getUser().getId())
-                .filter(id -> !id.equals(userId)) //예약 신청자 본인 : 초대되었다는 알림 제외
+                .filter(id -> !id.equals(userId)) // 예약 신청자 본인 : 초대되었다는 알림 제외
                 .toList();
 
         reservationEventPublisher.publishEventCreated(reservation, attendantUserIds);

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -82,14 +82,6 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         attendantWriter.saveAll(attendants);
 
-        // 승인 예약은 승인 이후 예약 알림
-        //        List<Long> attendantUserIds = attendants.stream()
-        //            .map(a -> a.getUser().getId())
-        //            .toList(); //각 attendantUserId 에 대해 넣지 못하는 문제 userId를 인자로 지정하게 해줘야하나
-        //
-        //
-        //        reservationEventPublisher.publishCreated(reservation, attendantUserIds);
-
         return ReservationResponseDto.fromEntity(reservation);
     }
 
@@ -167,7 +159,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         List<Long> attendantUserIds = reservation.getAttendants().stream()
                 .map(a -> a.getUser().getId())
-                .toList(); // TODO : 각 attendantUserId 에 대해 넣지 못하는 문제 userId를 인자로 지정하게 해줘야하나
+                .filter(id -> !id.equals(userId)) //예약 신청자 본인 : 초대되었다는 알림 제외
+                .toList();
 
         reservationEventPublisher.publishEventCreated(reservation, attendantUserIds);
 

--- a/qiin-be/src/main/java/com/beyond/qiin/infra/outbox/OutboxProcessor.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/infra/outbox/OutboxProcessor.java
@@ -9,8 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-
-
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/qiin-be/src/main/java/com/beyond/qiin/infra/outbox/OutboxProcessor.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/infra/outbox/OutboxProcessor.java
@@ -1,37 +1,39 @@
-// package com.beyond.qiin.infra.outbox;
-//
-// import com.beyond.qiin.domain.alarm.notification.entity.outbox.OutboxEvent;
-// import com.beyond.qiin.domain.alarm.notification.support.outbox.OutboxEventWriter;
-// import com.beyond.qiin.infra.kafka.KafkaProducerService;
-// import java.util.List;
-// import lombok.RequiredArgsConstructor;
-// import lombok.extern.slf4j.Slf4j;
-// import org.springframework.scheduling.annotation.Scheduled;
-// import org.springframework.stereotype.Component;
-//
-// @Slf4j
-// @Component
-// @RequiredArgsConstructor
-// public class OutboxProcessor { // 생성 / 수정으로 인해 outbox 생성 시 payload을 카프카 서버로 송신
-//
-//    private final OutboxEventWriter outboxEventWriter;
-//    private final KafkaProducerService kafkaProducerService;
-//
-//    @Scheduled(fixedDelay = 5000) // 5초마다 실행 - polling 방식으로 outbox 저장 확인
-//    public void processOutboxEvents() {
-//        List<OutboxEvent> events = outboxEventWriter.findUnpublishedEvents();
-//
-//        for (OutboxEvent event : events) {
-//            try { // 해당 토픽명으로 페이로드를 보냄
-//                kafkaProducerService.sendMessage(event.getEventType(), event.getPayload());
-//                event.markPublished(); // 상태 업데이트
-//                outboxEventWriter.save(event);
-//                log.info("sent event from outbox processor: {}", event);
-//            } catch (Exception e) {
-//                log.error("event publish failed: id={}, {}", event.getId(), e.getMessage());
-//                event.markFailed(); // 실패 상태로 변경 (필요 시)
-//                outboxEventWriter.save(event);
-//            }
-//        }
-//    }
-// }
+package com.beyond.qiin.infra.outbox;
+
+import com.beyond.qiin.domain.alarm.entity.OutboxEvent;
+import com.beyond.qiin.domain.alarm.support.OutboxEventWriter;
+import com.beyond.qiin.infra.kafka.KafkaProducerService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxProcessor { // 생성 / 수정으로 인해 outbox 생성 시 payload을 카프카 서버로 송신
+
+    private final OutboxEventWriter outboxEventWriter;
+    private final KafkaProducerService kafkaProducerService;
+
+    @Scheduled(fixedDelay = 5000) // 5초마다 실행 - polling 방식으로 outbox 저장 확인
+    public void processOutboxEvents() {
+        List<OutboxEvent> events = outboxEventWriter.findUnpublishedEvents();
+
+        for (OutboxEvent event : events) {
+            try { // 해당 토픽명으로 페이로드를 보냄
+                kafkaProducerService.sendMessage(event.getEventType(), event.getPayload());
+                event.markPublished(); // 상태 업데이트
+                outboxEventWriter.save(event);
+                log.info("sent event from outbox processor: {}", event);
+            } catch (Exception e) {
+                log.error("event publish failed: id={}, {}", event.getId(), e.getMessage());
+                event.markFailed(); // 실패 상태로 변경 (필요 시)
+                outboxEventWriter.save(event);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 알림 기능 활성화 
- sse 연결 시 401 인가 문제 보완
- 주최자 참여자 알림 메시지 구분

## ✨ 변경 사항 (Changes)
- [X] 주요 기능 추가 / 변경
- [X] 코드 리팩토링
- [X] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- refactor/31-notification

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#31 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- 표준 브라우저의 event source는 http custom header(authorization)을 지원하지 않음에 따라 custom sse token을 인자로 활용, 
불필요한 preauthorize는 제거 및 security config에서 해당 경로 permit all 
- NotificationCommandService 내 알림 발송 로직에서 신청자 ID(applicantId)를 참여자 알림 대상에서 제외(filter)하여 1인 1알림 원칙을 보장