### PR TITLE
Refactor/35 instant res k6

### DIFF
--- a/loadtest/results/summary.json
+++ b/loadtest/results/summary.json
@@ -1,0 +1,229 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 348,
+          "fails": 201,
+          "name": "201 created",
+          "path": "::201 created",
+          "id": "aa6ed7a4070500f66da438f64f36ffa0"
+        },
+        {
+          "fails": 0,
+          "name": "not server error",
+          "path": "::not server error",
+          "id": "46530ed95266e9d2708d8e7917f1e15f",
+          "passes": 549
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 30218.632213
+  },
+  "metrics": {
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 16.7138572,
+        "avg": 0.5419003369763206,
+        "min": 0.004416,
+        "med": 0.009248,
+        "max": 19.48319,
+        "p(95)": 0.07780400000000012
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 549,
+        "rate": 18.167599252352037
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 20,
+        "value": 1,
+        "min": 1
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 20,
+        "min": 20,
+        "max": 20
+      }
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "avg": 0.0910911912568306,
+        "min": 0.014275,
+        "med": 0.07296,
+        "max": 2.195317,
+        "p(95)": 0.19726520000000008,
+        "p(99)": 0.7092977599999983
+      },
+      "type": "trend"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 384136,
+        "rate": 12711.892361387072
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.366120218579235,
+        "passes": 201,
+        "fails": 348
+      },
+      "thresholds": {
+        "rate<0.10": {
+          "ok": false
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.8169398907103825,
+        "passes": 897,
+        "fails": 201
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 15.321505,
+        "p(95)": 0,
+        "p(99)": 12.732275,
+        "avg": 0.3729008433515483,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 1040.200591,
+        "p(95)": 358.35835360000016,
+        "p(99)": 1028.8404122,
+        "avg": 104.92052534608368,
+        "min": 17.900957,
+        "med": 44.682001
+      }
+    },
+    "http_req_receiving": {
+      "values": {
+        "med": 0.614921,
+        "max": 167.432953,
+        "p(95)": 6.875750000000002,
+        "p(99)": 22.249231079999973,
+        "avg": 2.017529251366119,
+        "min": 0.031529
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 1032.23683169,
+        "avg": 113.217702566092,
+        "min": 21.317244,
+        "med": 47.8802635,
+        "max": 1037.210809,
+        "p(95)": 391.8020316999999
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 549,
+        "rate": 18.167599252352037
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 1047.414166,
+        "max": 2053.861419,
+        "p(95)": 1362.0936420000003,
+        "p(99)": 2047.76937804,
+        "avg": 1109.396260029144,
+        "min": 1019.260095
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 11266.26108025957,
+        "count": 340451
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 107.02914578870678,
+        "min": 18.116857,
+        "med": 46.052626,
+        "max": 1041.578405,
+        "p(95)": 359.6422594000002,
+        "p(99)": 1031.9418986
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": true
+        }
+      }
+    }
+  }
+}

--- a/loadtest/results/summary.json
+++ b/loadtest/results/summary.json
@@ -1,27 +1,29 @@
 {
   "root_group": {
-    "name": "",
     "path": "",
     "id": "d41d8cd98f00b204e9800998ecf8427e",
     "groups": [],
     "checks": [
         {
-          "passes": 348,
-          "fails": 201,
+          "passes": 746,
+          "fails": 131,
           "name": "201 created",
           "path": "::201 created",
           "id": "aa6ed7a4070500f66da438f64f36ffa0"
         },
         {
+          "passes": 877,
           "fails": 0,
           "name": "not server error",
           "path": "::not server error",
-          "id": "46530ed95266e9d2708d8e7917f1e15f",
-          "passes": 549
+          "id": "46530ed95266e9d2708d8e7917f1e15f"
         }
-      ]
+      ],
+    "name": ""
   },
   "options": {
+    "summaryTimeUnit": "",
+    "noColor": false,
     "summaryTrendStats": [
       "avg",
       "min",
@@ -29,200 +31,198 @@
       "max",
       "p(95)",
       "p(99)"
-    ],
-    "summaryTimeUnit": "",
-    "noColor": false
+    ]
   },
   "state": {
     "isStdOutTTY": false,
     "isStdErrTTY": false,
-    "testRunDurationMs": 30218.632213
+    "testRunDurationMs": 38663.00728
   },
   "metrics": {
-    "http_req_blocked": {
-      "type": "trend",
+    "http_req_receiving": {
       "contains": "time",
       "values": {
-        "p(99)": 16.7138572,
-        "avg": 0.5419003369763206,
-        "min": 0.004416,
-        "med": 0.009248,
-        "max": 19.48319,
-        "p(95)": 0.07780400000000012
-      }
-    },
-    "http_reqs": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 549,
-        "rate": 18.167599252352037
-      }
-    },
-    "http_req_tls_handshaking": {
-      "values": {
-        "p(95)": 0,
-        "p(99)": 0,
-        "avg": 0,
-        "min": 0,
-        "med": 0,
-        "max": 0
-      },
-      "type": "trend",
-      "contains": "time"
-    },
-    "vus": {
-      "type": "gauge",
-      "contains": "default",
-      "values": {
-        "max": 20,
-        "value": 1,
-        "min": 1
-      }
-    },
-    "vus_max": {
-      "type": "gauge",
-      "contains": "default",
-      "values": {
-        "value": 20,
-        "min": 20,
-        "max": 20
-      }
-    },
-    "http_req_sending": {
-      "contains": "time",
-      "values": {
-        "avg": 0.0910911912568306,
-        "min": 0.014275,
-        "med": 0.07296,
-        "max": 2.195317,
-        "p(95)": 0.19726520000000008,
-        "p(99)": 0.7092977599999983
+        "med": 0.383661,
+        "max": 306.399173,
+        "p(95)": 31.754337,
+        "p(99)": 95.70027232000002,
+        "avg": 7.710540644241721,
+        "min": 0.035673
       },
       "type": "trend"
     },
-    "data_received": {
-      "type": "counter",
-      "contains": "data",
+    "http_req_tls_handshaking": {
+      "contains": "time",
       "values": {
-        "count": 384136,
-        "rate": 12711.892361387072
-      }
-    },
-    "http_req_failed": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 0.366120218579235,
-        "passes": 201,
-        "fails": 348
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(95)": 0,
+        "p(99)": 0
       },
-      "thresholds": {
-        "rate<0.10": {
-          "ok": false
-        }
-      }
+      "type": "trend"
     },
     "checks": {
       "type": "rate",
       "contains": "default",
       "values": {
-        "rate": 0.8169398907103825,
-        "passes": 897,
-        "fails": 201
+        "rate": 0.9253135689851767,
+        "passes": 1623,
+        "fails": 131
       }
-    },
-    "http_req_connecting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 15.321505,
-        "p(95)": 0,
-        "p(99)": 12.732275,
-        "avg": 0.3729008433515483,
-        "min": 0,
-        "med": 0
-      }
-    },
-    "http_req_waiting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 1040.200591,
-        "p(95)": 358.35835360000016,
-        "p(99)": 1028.8404122,
-        "avg": 104.92052534608368,
-        "min": 17.900957,
-        "med": 44.682001
-      }
-    },
-    "http_req_receiving": {
-      "values": {
-        "med": 0.614921,
-        "max": 167.432953,
-        "p(95)": 6.875750000000002,
-        "p(99)": 22.249231079999973,
-        "avg": 2.017529251366119,
-        "min": 0.031529
-      },
-      "type": "trend",
-      "contains": "time"
     },
     "http_req_duration{expected_response:true}": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(99)": 1032.23683169,
-        "avg": 113.217702566092,
-        "min": 21.317244,
-        "med": 47.8802635,
-        "max": 1037.210809,
-        "p(95)": 391.8020316999999
+        "max": 14764.31949,
+        "p(95)": 14161.52250875,
+        "p(99)": 14604.797311,
+        "avg": 1208.39979627748,
+        "min": 41.296669,
+        "med": 265.92155249999996
       }
     },
     "iterations": {
       "type": "counter",
       "contains": "default",
       "values": {
-        "count": 549,
-        "rate": 18.167599252352037
+        "count": 877,
+        "rate": 22.683181203384134
       }
     },
-    "iteration_duration": {
+    "http_req_sending": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 1047.414166,
-        "max": 2053.861419,
-        "p(95)": 1362.0936420000003,
-        "p(99)": 2047.76937804,
-        "avg": 1109.396260029144,
-        "min": 1019.260095
+        "min": 0.016843,
+        "med": 0.042496,
+        "max": 19.915078,
+        "p(95)": 0.5887809999999989,
+        "p(99)": 3.9013803200000026,
+        "avg": 0.23613031014823244
       }
+    },
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.10": {
+          "ok": false
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.14937286202964653,
+        "passes": 131,
+        "fails": 746
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 674431,
+        "rate": 17443.831906704178
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 62.537607,
+        "p(95)": 7.637326599999973,
+        "p(99)": 53.08490036,
+        "avg": 2.2394123591790196,
+        "min": 0
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "avg": 2189.562691633975,
+        "min": 1041.831585,
+        "med": 1258.586097,
+        "max": 15766.035403,
+        "p(95)": 15132.1992452,
+        "p(99)": 15607.41819584
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "max": 14764.31949,
+        "p(95)": 14128.4230824,
+        "p(99)": 14604.38799928,
+        "avg": 1182.002094383124,
+        "min": 41.296669,
+        "med": 256.540503
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": false
+        }
+      },
+      "type": "trend"
     },
     "data_sent": {
       "type": "counter",
       "contains": "data",
       "values": {
-        "rate": 11266.26108025957,
-        "count": 340451
+        "count": 543854,
+        "rate": 14066.520901009435
       }
     },
-    "http_req_duration": {
+    "http_req_waiting": {
+      "values": {
+        "avg": 1174.0554234287342,
+        "min": 39.858732,
+        "med": 251.002036,
+        "max": 14764.179193,
+        "p(95)": 14128.148795000001,
+        "p(99)": 14589.5978564
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_blocked": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "avg": 107.02914578870678,
-        "min": 18.116857,
-        "med": 46.052626,
-        "max": 1041.578405,
-        "p(95)": 359.6422594000002,
-        "p(99)": 1031.9418986
-      },
-      "thresholds": {
-        "p(95)<1500": {
-          "ok": true
-        }
+        "avg": 3.1090848141391123,
+        "min": 0.004484,
+        "med": 0.009762,
+        "max": 85.419618,
+        "p(95)": 21.532061999999968,
+        "p(99)": 68.50641904000001
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 877,
+        "rate": 22.683181203384134
       }
     }
   }

--- a/loadtest/scripts/instant_reservation_test.js
+++ b/loadtest/scripts/instant_reservation_test.js
@@ -23,7 +23,7 @@ export const options = {
   scenarios: {
     instant_reservation_load: {
       executor: 'constant-vus', //vu 수 고정 
-      vus: 20, //virtual user 20 
+      vus: 50, //virtual user 20 
       duration: '30s', //30초동안 요청
     },
   },

--- a/loadtest/scripts/instant_reservation_test.js
+++ b/loadtest/scripts/instant_reservation_test.js
@@ -1,0 +1,112 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+const users = new SharedArray('users', function () {
+  return open('../../qiin-be/output/user_tokens.csv')
+    .split('\n')
+    .slice(1)
+    .filter(Boolean)
+    .map(line => {
+      const [userId, accessToken] = line.split(',');
+      return {
+        userId: userId.trim(),
+        accessToken: accessToken.trim(),
+      };
+    });
+});
+
+//test option
+export const options = {
+  scenarios: {
+    instant_reservation_load: {
+      executor: 'constant-vus', //vu 수 고정 
+      vus: 20, //virtual user 20 
+      duration: '30s', //30초동안 요청
+    },
+  },
+  thresholds: { //성능 기준 
+    http_req_failed: ['rate<0.10'], //실패율 10% 이내  
+    http_req_duration: ['p(95)<1500'], //95% 요청은 1.5초 안
+  },
+  //통계 출력 설정 
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)'],
+};
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+//startAt, endAt 생성 - reservation csv 따로 생성 x 
+function buildFutureTimeSlot() {
+  const base = new Date();
+
+  // 현재 기준 7일 뒤부터 테스트
+  base.setUTCDate(base.getUTCDate() + 7);
+
+  // 0~20일 사이로 날짜 분산
+  base.setUTCDate(base.getUTCDate() + randomInt(0, 20));
+
+  // 09시~17시 시작, 1시간 예약
+  const startHour = randomInt(9, 17);
+
+  base.setUTCHours(startHour, 0, 0, 0);
+
+  //예약 종료 시간 
+  const startAt = new Date(base);
+  
+  //예약 시작 시간 
+  const endAt = new Date(startAt);
+  endAt.setUTCHours(startAt.getUTCHours() + 1); 
+
+  return {
+    startAt: startAt.toISOString(),
+    endAt: endAt.toISOString(),
+  };
+}
+
+//main test logic - vu가 반복 실행하는 함수 (main의 역할)
+export default function () {
+  //vu 1~20 -> user 배열을 순환해서 사용
+  const user = users[(__VU - 1) % users.length]; //__VU : k6에서 자동으로 주는 값, 현재 실행 중 가상 유저의 번호 
+
+  //asset id 
+  const assetId = randomInt(1, 50);
+
+  const slot = buildFutureTimeSlot();
+
+  const url = `${BASE_URL}/api/v1/reservations/${assetId}/instant-confirm`;
+
+  //create reservation dto 
+  const payload = JSON.stringify({
+    startAt: slot.startAt,
+    endAt: slot.endAt,
+    description: 'k6 instant reservation performance test',
+    attendantIds: [],
+  });
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${user.accessToken}`,
+    },
+  };
+
+  //http post 요청 실행 결과를 res로 저장
+  const res = http.post(url, payload, params);
+
+  check(res, {
+    '201 created': r => r.status === 201, //생성 성공
+    'not server error': r => r.status < 500, //500 : 실패
+  });
+
+  sleep(1); //각 vu 1초 쉰 뒤 반복 
+}
+
+export function handleSummary(data) {
+  return {
+    '../results/summary.json': JSON.stringify(data, null, 2), //결과를 json으로 저장 
+  };
+} 

--- a/qiin-be/docker-compose.yml
+++ b/qiin-be/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
 
   prometheus: #지표 수집과 저장
-    image: prom/prometheus:v2.54.1
+    image: prom/prometheus:v3.0.1
     container_name: prometheus
     restart: unless-stopped
     volumes:

--- a/qiin-be/docker-compose.yml
+++ b/qiin-be/docker-compose.yml
@@ -83,11 +83,11 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
 
   prometheus: #지표 수집과 저장
-    image: prom/prometheus:v3.1.2
+    image: prom/prometheus:v2.54.1
     container_name: prometheus
     restart: unless-stopped
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml #참고할 설정파일 경로
+      - ./prometheus/prometheus.dev.yml:/etc/prometheus/prometheus.yml #참고할 설정파일 경로
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/qiin-be/prometheus/prometheus.dev.yml
+++ b/qiin-be/prometheus/prometheus.dev.yml
@@ -1,6 +1,6 @@
 #전역 설정
 global:
-  scrape_interval: ${SCRAPE_INTERVAL} # 5초마다 데이터 수집(부하테스트용)
+  scrape_interval: 5s # 5초마다 데이터 수집(부하테스트용)
 
 #감시할 대상에 대한 정의
 scrape_configs:

--- a/qiin-be/prometheus/prometheus.prod.yml
+++ b/qiin-be/prometheus/prometheus.prod.yml
@@ -1,0 +1,16 @@
+#전역 설정
+global:
+  scrape_interval: 15s # 운영용
+
+#감시할 대상에 대한 정의
+scrape_configs:
+  # spring boot application
+  - job_name: 'spring-app'
+    metrics_path: '/actuator/prometheus' #앱 안으로 접근해야하는 경로
+    static_configs:
+      - targets: ['qiin-app:8080'] #데이터를 가져올 목적지 (컨테이너 이름)
+
+  # maria db
+  - job_name: 'mariadb'
+    static_configs: #maria db 는 직접 프로메테우스를 이해하지 못하기 때문에 중간에 mariadb-exporter을 둬야함
+      - targets: ['mariadb-exporter:9104']

--- a/qiin-be/src/main/resources/application.yml
+++ b/qiin-be/src/main/resources/application.yml
@@ -63,8 +63,8 @@ cors:
 management:
   endpoints: #http 로 정보 외부로 노출
     web:
-      exposure: #/actuator/prometheus, /actuator/health, /actuator/info의 경로
-        include: prometheus, health, info #프로메테우스가 읽어갈 수 있는 형식의 데이터, 서버의 상태(up, down), 애플리케이션 정보
+      exposure: #/actuator/prometheus, /actuator/health
+        include: prometheus, health #프로메테우스가 읽어갈 수 있는 형식의 데이터, 서버의 상태(up, down), 애플리케이션 정보
   endpoint:
     prometheus:
       enabled: true #프로메테우스용 데이터 수집 활성화


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 선착순 예약하기 용도의 k6 부하 테스트 스크립트 작성

## ✨ 변경 사항 (Changes)
- [X] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- refactor/35-instant-res-k6

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#35 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- 사용자 토큰 파일 활용해 자원, 시간대 다른 임의의 예약 요청을 보내도록 로직 작성 
- 결과는 loadtest/results/summary.js로 저장 (processor 있는 상태에서 consume 시의 과정에 대한 성능 기록)
- virtual user 50 (20으로는 processor 이후 작업 유무에 대한 차이 미미함)
- tag : loadtest-vu50-single-server-with-consumer

- 실행 방법
*k6 script 인 instant_reservation_test.js가 있는 곳 기준으로 사용자 토큰 경로, 결과 경로(summary.js) 설정해두었기 때문에 loadtest/scripts 의 경로에서 실행 필요
```
docker run --rm -i `
  -v "D:\projects\be18-fin-jelly-queuein-be:/work" `
  -w /work/loadtest/scripts `
  -e BASE_URL=http://host.docker.internal:8080 `
  grafana/k6 run ./instant_reservation_test.js
```

*실행 후 해당 데이터 삭제 필요(동일한 실행 조건을 만드는 용도)