### PR TITLE
신청 예약 목록 조회의 n + 1 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,8 @@ gradle.properties
 /qiin-be/qiin-api/src/main/generated/
 /qiin-be/qiin-notification/src/main/generated/
 
+### logs
+*.log
+
 ### user token csv ###
 /qiin-be/output

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ Temporary Items
 
 gradle.properties
 /qiin-be/src/main/generated/
+/qiin-be/qiin-api/src/main/generated/
+/qiin-be/qiin-notification/src/main/generated/
 
 ### user token csv ###
 /qiin-be/output

--- a/loadtest/results/applied-reservations-after-asset-status-vu30-summary.json
+++ b/loadtest/results/applied-reservations-after-asset-status-vu30-summary.json
@@ -1,0 +1,246 @@
+{
+  "root_group": {
+    "checks": [
+      {
+        "name": "200 ok",
+        "path": "::200 ok",
+        "id": "1f6e29081d29f360ff053a0fe4f41d92",
+        "passes": 2,
+        "fails": 10
+      },
+      {
+        "name": "not server error",
+        "path": "::not server error",
+        "id": "46530ed95266e9d2708d8e7917f1e15f",
+        "passes": 2,
+        "fails": 10
+      },
+      {
+        "fails": 0,
+        "name": "response body exists",
+        "path": "::response body exists",
+        "id": "15ea59e3ffa2f79ff7115cfff133b82c",
+        "passes": 12
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 59853.930445
+  },
+  "metrics": {
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.4444444444444444,
+        "passes": 16,
+        "fails": 20
+      }
+    },
+    "data_sent": {
+      "values": {
+        "count": 15459,
+        "rate": 258.2787777689108
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 12,
+        "rate": 0.20048808676026456
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 3.298014,
+        "med": 56.462427000000005,
+        "max": 57.431289,
+        "p(90)": 57.3249486,
+        "p(95)": 57.3821894,
+        "p(99)": 57.42146908,
+        "avg": 47.742342916666665
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 30,
+        "min": 30,
+        "max": 30
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 60.85264185,
+        "p(99)": 60.85500597,
+        "avg": 50.852778916666665,
+        "min": 6.495706,
+        "med": 59.35105,
+        "max": 60.855597,
+        "p(90)": 60.845327399999995
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 18,
+        "min": 18,
+        "max": 30
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 13718,
+        "rate": 229.1912978481091
+      },
+      "type": "counter"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0.20048808676026456,
+        "count": 12
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.3378495833333333,
+        "min": 0.034236,
+        "med": 0.2944905,
+        "max": 1.097447,
+        "p(90)": 0.6714758000000001,
+        "p(95)": 0.8718716499999997,
+        "p(99)": 1.0523319300000002
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 68.76031874999998,
+        "p(99)": 75.29616455000001,
+        "avg": 31.118238333333327,
+        "min": 5.442359,
+        "med": 22.6437765,
+        "max": 76.930126,
+        "p(90)": 61.671681299999996
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 31828.972015500003,
+        "max": 58567.901351,
+        "p(90)": 48505.576891200006,
+        "p(95)": 54048.076733999995,
+        "p(99)": 57663.936427600005,
+        "avg": 35598.2102425,
+        "min": 31774.525623
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 57396.77205003,
+        "avg": 53367.4087555,
+        "min": 49255.813557,
+        "med": 53367.4087555,
+        "max": 57479.003954,
+        "p(90)": 56656.6849143,
+        "p(95)": 57067.84443415
+      }
+    },
+    "http_req_failed": {
+      "values": {
+        "passes": 10,
+        "fails": 2,
+        "rate": 0.8333333333333334
+      },
+      "thresholds": {
+        "rate<0.10": {
+          "ok": false
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 52956.24923564999,
+        "p(99)": 56574.453010330006,
+        "avg": 34461.08326516667,
+        "min": 30609.747255,
+        "med": 30686.535709,
+        "max": 57479.003954,
+        "p(90)": 47405.20265220001
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 30587.701731,
+        "med": 30663.7642485,
+        "max": 57458.262244,
+        "p(90)": 47382.311833700005,
+        "p(95)": 52933.283920199996,
+        "p(99)": 56553.26657924,
+        "avg": 34429.62717725
+      }
+    }
+  }
+}

--- a/loadtest/results/applied-reservations-after-asset-status-vu5-summary.json
+++ b/loadtest/results/applied-reservations-after-asset-status-vu5-summary.json
@@ -1,0 +1,246 @@
+{
+  "metrics": {
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 5150,
+        "rate": 146.75306003809425
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 16310.509337399999,
+        "min": 14053.285949,
+        "med": 16324.8375725,
+        "max": 17825.428568,
+        "p(90)": 17798.2342706,
+        "p(95)": 17811.8314193,
+        "p(99)": 17822.70913826
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 30,
+        "fails": 0
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 10,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.10": {
+          "ok": true
+        }
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 43090,
+        "rate": 1227.881428551744
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "max": 6.47313,
+        "p(90)": 6.4176063,
+        "p(95)": 6.44536815,
+        "p(99)": 6.46757763,
+        "avg": 2.2542215000000003,
+        "min": 0,
+        "med": 1.569049
+      },
+      "type": "trend"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 10,
+        "rate": 0.2849573981322219
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 10,
+        "rate": 0.2849573981322219
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 17366.8914825,
+        "max": 18910.747823,
+        "p(90)": 18880.1629007,
+        "p(95)": 18895.455361850003,
+        "p(99)": 18907.68933077,
+        "avg": 17353.743455,
+        "min": 15064.350421
+      }
+    },
+    "http_req_blocked": {
+      "values": {
+        "p(90)": 8.376244499999999,
+        "p(95)": 8.657388749999999,
+        "p(99)": 8.88230415,
+        "avg": 3.3044785000000005,
+        "min": 0.006114,
+        "med": 2.5015155000000004,
+        "max": 8.938533
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 17825.428568,
+        "p(90)": 17798.2342706,
+        "p(95)": 17811.8314193,
+        "p(99)": 17822.70913826,
+        "avg": 16310.509337399999,
+        "min": 14053.285949,
+        "med": 16324.8375725
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": false
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 3,
+        "min": 3,
+        "max": 5
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 7.39675984,
+        "avg": 2.8714492,
+        "min": 1.013403,
+        "med": 2.2914645,
+        "max": 7.529197,
+        "p(90)": 6.2048254,
+        "p(95)": 6.8670111999999985
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.40650591,
+        "avg": 0.10667299999999999,
+        "min": 0.018541,
+        "med": 0.06762599999999999,
+        "max": 0.433056,
+        "p(90)": 0.1675550999999999,
+        "p(95)": 0.3003055499999997
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 17820.12620688,
+        "avg": 16307.5312152,
+        "min": 14052.07355,
+        "med": 16320.480587999999,
+        "max": 17822.794659,
+        "p(90)": 17796.1101378,
+        "p(95)": 17809.4523984
+      }
+    }
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 10,
+          "fails": 0,
+          "name": "200 ok",
+          "path": "::200 ok",
+          "id": "1f6e29081d29f360ff053a0fe4f41d92"
+        },
+        {
+          "name": "not server error",
+          "path": "::not server error",
+          "id": "46530ed95266e9d2708d8e7917f1e15f",
+          "passes": 10,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "response body exists",
+          "path": "::response body exists",
+          "id": "15ea59e3ffa2f79ff7115cfff133b82c",
+          "passes": 10
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 35092.965003
+  }
+}

--- a/loadtest/results/applied-reservations-after-reservable-bulk-vu5-summary.json
+++ b/loadtest/results/applied-reservations-after-reservable-bulk-vu5-summary.json
@@ -1,0 +1,246 @@
+{
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 30550.072864
+  },
+  "metrics": {
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "p(99)": 0.28127888000000023,
+        "avg": 0.06264672413793107,
+        "min": 0.014745,
+        "med": 0.048316,
+        "max": 0.321469,
+        "p(90)": 0.12296739999999999,
+        "p(95)": 0.133737
+      },
+      "type": "trend"
+    },
+    "http_req_failed": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 145
+      },
+      "thresholds": {
+        "rate<0.10": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 145,
+        "rate": 4.746306191985127
+      },
+      "type": "counter"
+    },
+    "http_req_receiving": {
+      "values": {
+        "avg": 1.4647101103448281,
+        "min": 0.062067,
+        "med": 0.745671,
+        "max": 8.461063,
+        "p(90)": 3.943839399999999,
+        "p(95)": 5.353677399999995,
+        "p(99)": 8.063230720000002
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 435,
+        "fails": 0
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 5,
+        "value": 5,
+        "min": 5
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "p(99)": 100.3845692,
+        "avg": 46.547600268965546,
+        "min": 18.353655,
+        "med": 41.532107,
+        "max": 101.467007,
+        "p(90)": 78.40607339999998,
+        "p(95)": 85.1029634
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 45.020243434482765,
+        "min": 17.76153,
+        "med": 39.944968,
+        "max": 100.604199,
+        "p(90)": 75.10101819999998,
+        "p(95)": 83.30691219999997,
+        "p(99)": 96.76566980000001
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 5,
+        "max": 5
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 621905,
+        "rate": 20356.90725742421
+      },
+      "type": "counter"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.3314411586206895,
+        "min": 0.00434,
+        "med": 0.009381,
+        "max": 10.789977,
+        "p(90)": 0.0167406,
+        "p(95)": 0.038048399999999975,
+        "p(99)": 10.52359112
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 1103.309238,
+        "p(90)": 1082.7632508,
+        "p(95)": 1086.2668264,
+        "p(99)": 1101.7019413599999,
+        "avg": 1048.2175852137932,
+        "min": 1018.740568,
+        "med": 1043.122318
+      }
+    },
+    "iterations": {
+      "contains": "default",
+      "values": {
+        "count": 145,
+        "rate": 4.746306191985127
+      },
+      "type": "counter"
+    },
+    "data_sent": {
+      "values": {
+        "count": 74675,
+        "rate": 2444.3476888723403
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 85.1029634,
+        "p(99)": 100.3845692,
+        "avg": 46.547600268965546,
+        "min": 18.353655,
+        "med": 41.532107,
+        "max": 101.467007,
+        "p(90)": 78.40607339999998
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.2143141931034483,
+        "min": 0,
+        "med": 0,
+        "max": 7.728028,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 7.31337016
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    }
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "id": "1f6e29081d29f360ff053a0fe4f41d92",
+          "passes": 145,
+          "fails": 0,
+          "name": "200 ok",
+          "path": "::200 ok"
+        },
+        {
+          "name": "not server error",
+          "path": "::not server error",
+          "id": "46530ed95266e9d2708d8e7917f1e15f",
+          "passes": 145,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "response body exists",
+          "path": "::response body exists",
+          "id": "15ea59e3ffa2f79ff7115cfff133b82c",
+          "passes": 145
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": ""
+  }
+}

--- a/loadtest/results/applied-reservations-nplus1-summary.json
+++ b/loadtest/results/applied-reservations-nplus1-summary.json
@@ -1,0 +1,246 @@
+{
+  "root_group": {
+    "checks": [
+      {
+        "name": "200 ok",
+        "path": "::200 ok",
+        "id": "1f6e29081d29f360ff053a0fe4f41d92",
+        "passes": 2,
+        "fails": 0
+      },
+      {
+        "passes": 2,
+        "fails": 0,
+        "name": "not server error",
+        "path": "::not server error",
+        "id": "46530ed95266e9d2708d8e7917f1e15f"
+      },
+      {
+        "fails": 0,
+        "name": "response body exists",
+        "path": "::response body exists",
+        "id": "15ea59e3ffa2f79ff7115cfff133b82c",
+        "passes": 2
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "max",
+      "p(90)",
+      "p(95)",
+      "p(99)"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 60476.541416,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 8578,
+        "rate": 141.8401217919277
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 48406.00896505,
+        "p(99)": 48492.48682821,
+        "avg": 47433.1330045,
+        "min": 46352.159715,
+        "med": 47433.1330045,
+        "max": 48514.106294,
+        "p(90)": 48297.9116361
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "rate": 0.03307067423453665,
+        "count": 2
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6,
+        "fails": 0
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "thresholds": {
+        "rate<0.10": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "values": {
+        "value": 18,
+        "min": 18,
+        "max": 20
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 11.9434152,
+        "p(99)": 11.945514240000001,
+        "avg": 11.919801,
+        "min": 11.893563,
+        "med": 11.919801,
+        "max": 11.946039,
+        "p(90)": 11.9407914
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "max": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "avg": 0,
+        "min": 0
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2,
+        "rate": 0.03307067423453665
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "avg": 4.133631,
+        "min": 0.336336,
+        "med": 4.133631,
+        "max": 7.930926,
+        "p(90)": 7.171467000000001,
+        "p(95)": 7.5511965,
+        "p(99)": 7.854980100000001
+      },
+      "type": "trend"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 20,
+        "min": 20,
+        "max": 20
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.3691005,
+        "min": 0.044574,
+        "med": 0.3691005,
+        "max": 0.693627,
+        "p(90)": 0.6287217,
+        "p(95)": 0.6611743499999999,
+        "p(99)": 0.68713647
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 10306,
+        "rate": 170.41318433056736
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 46588.081866,
+        "med": 47665.016835999995,
+        "max": 48741.951806,
+        "p(90)": 48526.564812,
+        "p(95)": 48634.258309,
+        "p(99)": 48720.4131066,
+        "avg": 47665.016835999995
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 47669.5195675,
+        "max": 48750.576359,
+        "p(90)": 48534.365000699996,
+        "p(95)": 48642.47067985,
+        "p(99)": 48728.95522317,
+        "avg": 47669.5195675,
+        "min": 46588.462776
+      },
+      "thresholds": {
+        "p(95)<1500": {
+          "ok": false
+        }
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "p(99)": 48728.95522317,
+        "avg": 47669.5195675,
+        "min": 46588.462776,
+        "med": 47669.5195675,
+        "max": 48750.576359,
+        "p(90)": 48534.365000699996,
+        "p(95)": 48642.47067985
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 15.06910458,
+        "avg": 14.854317,
+        "min": 14.635146,
+        "med": 14.854317,
+        "max": 15.073488,
+        "p(90)": 15.0296538,
+        "p(95)": 15.0515709
+      }
+    }
+  }
+}

--- a/loadtest/scripts/applied_reservation_query_opt.js
+++ b/loadtest/scripts/applied_reservation_query_opt.js
@@ -32,11 +32,22 @@ const users = new SharedArray('users', function () {
     });
 });
 
+//1명 실행 용도
+// export const options = {
+//  scenarios: {
+//    applied_reservations_nplus1_load: {
+//      executor: 'shared-iterations',
+//      vus: 1,
+//      iterations: 1,
+//    },
+//  },
+// };
+
 export const options = {
   scenarios: {
     applied_reservations_nplus1_load: {
       executor: 'constant-vus',
-      vus: Number(__ENV.VUS || 30),
+      vus: Number(__ENV.VUS || 5),
       duration: __ENV.DURATION || '30s',
     },
   },
@@ -94,7 +105,7 @@ export default function () {
 }
 
 export function handleSummary(data) {
-  const out = __ENV.OUT || '../results/applied-reservations-nplus1-summary.json';
+  const out = __ENV.OUT || './results/applied-reservations-after-reservable-bulk-vu5-summary.json';
 
   //applied-reservations-after-asset-status-projection.json
   //applied-reservations-after-reservable-bulk.json

--- a/loadtest/scripts/applied_reservation_query_opt.js
+++ b/loadtest/scripts/applied_reservation_query_opt.js
@@ -1,0 +1,133 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+const TOKEN_CSV_PATH = __ENV.TOKEN_CSV_PATH || '../../qiin-be/output/user_tokens.csv';
+
+const PAGE = __ENV.PAGE || '0';
+const SIZE = __ENV.SIZE || '20';
+
+// 전후 비교에서는 같은 검색 조건으로 고정해서 실행
+const RESERVATION_STATUS = __ENV.RESERVATION_STATUS || '';
+const START_DATE = __ENV.START_DATE || '';
+const END_DATE = __ENV.END_DATE || '';
+const APPLICANT_NAME = __ENV.APPLICANT_NAME || '';
+const ASSET_NAME = __ENV.ASSET_NAME || '';
+const CATEGORY_ID = __ENV.CATEGORY_ID || '';
+
+const users = new SharedArray('users', function () {
+  return open(TOKEN_CSV_PATH)
+    .split('\n')
+    .slice(1)
+    .filter(Boolean)
+    .map(line => {
+      const [userId, accessToken] = line.split(',');
+
+      return {
+        userId: userId.trim(),
+        accessToken: accessToken.trim(),
+      };
+    });
+});
+
+export const options = {
+  scenarios: {
+    applied_reservations_nplus1_load: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 30),
+      duration: __ENV.DURATION || '30s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.10'],
+    http_req_duration: ['p(95)<1500'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+};
+
+function addParam(params, key, value) {
+  if (value !== undefined && value !== null && value !== '') {
+    params.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+  }
+}
+
+function buildQuery() {
+  const params = [];
+
+  addParam(params, 'page', PAGE);
+  addParam(params, 'size', SIZE);
+
+  addParam(params, 'reservationStatus', RESERVATION_STATUS);
+  addParam(params, 'startDate', START_DATE);
+  addParam(params, 'endDate', END_DATE);
+  addParam(params, 'applicantName', APPLICANT_NAME);
+  addParam(params, 'assetName', ASSET_NAME);
+  addParam(params, 'categoryId', CATEGORY_ID);
+
+  return params.join('&');
+}
+
+export default function () {
+  const user = users[(__VU - 1) % users.length];
+
+  const query = buildQuery();
+  const url = `${BASE_URL}/api/v1/reservations/pending?${query}`;
+
+  const params = {
+    headers: {
+      Authorization: `Bearer ${user.accessToken}`,
+      Accept: 'application/json',
+    },
+  };
+
+  const res = http.get(url, params);
+
+  check(res, {
+    '200 ok': r => r.status === 200,
+    'not server error': r => r.status < 500,
+    'response body exists': r => r.body && r.body.length > 0,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  const out = __ENV.OUT || '../results/applied-reservations-nplus1-summary.json';
+
+  //applied-reservations-after-asset-status-projection.json
+  //applied-reservations-after-reservable-bulk.json
+
+
+  return {
+    [out]: JSON.stringify(data, null, 2),
+    stdout: JSON.stringify({
+      api: 'GET /api/v1/reservations/pending',
+      purpose: 'applied reservations N+1 / bulk query comparison',
+      cache: 'spring.cache.type=none',
+      tokenCsvPath: TOKEN_CSV_PATH,
+      page: PAGE,
+      size: SIZE,
+      reservationStatus: RESERVATION_STATUS || null,
+      startDate: START_DATE || null,
+      endDate: END_DATE || null,
+      applicantName: APPLICANT_NAME || null,
+      assetName: ASSET_NAME || null,
+      categoryId: CATEGORY_ID || null,
+      metrics: {
+        http_reqs: data.metrics.http_reqs?.count,
+        iterations: data.metrics.iterations?.count,
+        checks_rate: data.metrics.checks?.rate,
+        http_req_failed_rate: data.metrics.http_req_failed?.rate,
+        http_req_duration_avg: data.metrics.http_req_duration?.avg,
+        http_req_duration_min: data.metrics.http_req_duration?.min,
+        http_req_duration_med: data.metrics.http_req_duration?.med,
+        http_req_duration_p90: data.metrics.http_req_duration?.percentiles?.['90'],
+        http_req_duration_p95: data.metrics.http_req_duration?.percentiles?.['95'],
+        http_req_duration_p99: data.metrics.http_req_duration?.percentiles?.['99'],
+        http_req_duration_max: data.metrics.http_req_duration?.max,
+      },
+    }, null, 2),
+  };
+}

--- a/qiin-be/agent.md
+++ b/qiin-be/agent.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+- After changing Java code, run `.\gradlew.bat :qiin-api:spotlessApply` before final verification.

--- a/qiin-be/qiin-api-bootrun.err.log
+++ b/qiin-be/qiin-api-bootrun.err.log
@@ -1,0 +1,14 @@
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':qiin-api:bootRun'.
+> Process 'command 'C:\Users\park\.jdks\temurin-21.0.8\bin\java.exe'' finished with non-zero exit value 1
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+> Get more help at https://help.gradle.org.
+
+BUILD FAILED in 36s

--- a/qiin-be/qiin-api-bootrun.log
+++ b/qiin-be/qiin-api-bootrun.log
@@ -1,0 +1,128 @@
+> Task :updateGitHooks UP-TO-DATE
+
+> Task :makeGitHooksExecutable
+Skipping chmod (Windows detected) - Git hooks assumed already executable.
+
+> Task :qiin-api:compileJava UP-TO-DATE
+> Task :qiin-api:processResources
+> Task :qiin-api:classes
+> Task :qiin-api:resolveMainClassName
+
+> Task :qiin-api:bootRun
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+
+ :: Spring Boot ::                (v3.5.4)
+
+2026-06-16T18:57:58.531+09:00  INFO 21800 --- [qiin-api] [  restartedMain] com.beyond.qiin.QiinApiApplication       : Starting QiinApiApplication using Java 21.0.8 with PID 21800 (D:\projects\be18-fin-jelly-queuein-be\qiin-be\qiin-api\build\classes\java\main started by park in D:\projects\be18-fin-jelly-queuein-be\qiin-be\qiin-api)
+2026-06-16T18:57:58.536+09:00  INFO 21800 --- [qiin-api] [  restartedMain] com.beyond.qiin.QiinApiApplication       : The following 1 profile is active: "dev"
+2026-06-16T18:57:58.659+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : Devtools property defaults active! Set 'spring.devtools.add-properties' to 'false' to disable
+2026-06-16T18:57:58.659+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .e.DevToolsPropertyDefaultsPostProcessor : For additional web related logging consider setting the 'logging.level.web' property to 'DEBUG'
+2026-06-16T18:58:07.631+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2026-06-16T18:58:07.631+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-06-16T18:58:08.585+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 941 ms. Found 17 JPA repository interfaces.
+2026-06-16T18:58:08.586+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2026-06-16T18:58:08.586+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2026-06-16T18:58:08.595+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 7 ms. Found 2 JPA repository interfaces.
+2026-06-16T18:58:08.597+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Multiple Spring Data modules found, entering strict repository configuration mode
+2026-06-16T18:58:08.597+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode.
+2026-06-16T18:58:08.656+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 39 ms. Found 7 Redis repository interfaces.
+2026-06-16T18:58:11.294+09:00  INFO 21800 --- [qiin-api] [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
+2026-06-16T18:58:11.319+09:00  INFO 21800 --- [qiin-api] [  restartedMain] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
+2026-06-16T18:58:11.319+09:00  INFO 21800 --- [qiin-api] [  restartedMain] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.43]
+2026-06-16T18:58:11.440+09:00  INFO 21800 --- [qiin-api] [  restartedMain] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
+2026-06-16T18:58:11.442+09:00  INFO 21800 --- [qiin-api] [  restartedMain] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 12781 ms
+2026-06-16T18:58:11.690+09:00  INFO 21800 --- [qiin-api] [  restartedMain] c.b.qiin.security.jwt.JwtTokenProvider   : JWT SecretKey 초기화 완료
+2026-06-16T18:58:12.832+09:00 ERROR 21800 --- [qiin-api] [  restartedMain] com.beyond.qiin.config.RedisConfig       : Redis 연결 실패: redis:6379, 에러=Unable to connect to Redis
+2026-06-16T18:58:13.938+09:00  INFO 21800 --- [qiin-api] [  restartedMain] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
+2026-06-16T18:58:17.775+09:00  WARN 21800 --- [qiin-api] [  restartedMain] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [com/beyond/qiin/config/JpaRepositoryConfig.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Socket fail to connect to mariadb. mariadb
+-------------------------------------------------------------------------------------
+SQL State  : 08000
+Error Code : 0
+Message    : Socket fail to connect to mariadb. mariadb
+
+2026-06-16T18:58:17.887+09:00  INFO 21800 --- [qiin-api] [  restartedMain] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
+2026-06-16T18:58:17.914+09:00  INFO 21800 --- [qiin-api] [  restartedMain] .s.b.a.l.ConditionEvaluationReportLogger : 
+
+Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
+2026-06-16T18:58:17.936+09:00 ERROR 21800 --- [qiin-api] [  restartedMain] o.s.boot.SpringApplication               : Application run failed
+
+org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [com/beyond/qiin/config/JpaRepositoryConfig.class]: Failed to initialize dependency 'flywayInitializer' of LoadTimeWeaverAware bean 'entityManagerFactory': Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Socket fail to connect to mariadb. mariadb
+-------------------------------------------------------------------------------------
+SQL State  : 08000
+Error Code : 0
+Message    : Socket fail to connect to mariadb. mariadb
+
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:328) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:207) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:970) ~[spring-context-6.2.9.jar:6.2.9]
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627) ~[spring-context-6.2.9.jar:6.2.9]
+	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.5.4.jar:3.5.4]
+	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) ~[spring-boot-3.5.4.jar:3.5.4]
+	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) ~[spring-boot-3.5.4.jar:3.5.4]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) ~[spring-boot-3.5.4.jar:3.5.4]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.5.4.jar:3.5.4]
+	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.5.4.jar:3.5.4]
+	at com.beyond.qiin.QiinApiApplication.main(QiinApiApplication.java:20) ~[main/:na]
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
+	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
+	at org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:50) ~[spring-boot-devtools-3.5.4.jar:3.5.4]
+Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Unable to obtain connection from database: Socket fail to connect to mariadb. mariadb
+-------------------------------------------------------------------------------------
+SQL State  : 08000
+Error Code : 0
+Message    : Socket fail to connect to mariadb. mariadb
+
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1826) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:607) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:529) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:373) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-6.2.9.jar:6.2.9]
+	... 13 common frames omitted
+Caused by: org.flywaydb.core.internal.exception.FlywaySqlException: Unable to obtain connection from database: Socket fail to connect to mariadb. mariadb
+-------------------------------------------------------------------------------------
+SQL State  : 08000
+Error Code : 0
+Message    : Socket fail to connect to mariadb. mariadb
+
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:71) ~[flyway-core-11.7.2.jar:na]
+	at org.flywaydb.core.internal.jdbc.JdbcConnectionFactory.<init>(JdbcConnectionFactory.java:76) ~[flyway-core-11.7.2.jar:na]
+	at org.flywaydb.core.FlywayExecutor.execute(FlywayExecutor.java:136) ~[flyway-core-11.7.2.jar:na]
+	at org.flywaydb.core.Flyway.migrate(Flyway.java:188) ~[flyway-core-11.7.2.jar:na]
+	at org.springframework.boot.autoconfigure.flyway.FlywayMigrationInitializer.afterPropertiesSet(FlywayMigrationInitializer.java:66) ~[spring-boot-autoconfigure-3.5.4.jar:3.5.4]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1873) ~[spring-beans-6.2.9.jar:6.2.9]
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1822) ~[spring-beans-6.2.9.jar:6.2.9]
+	... 20 common frames omitted
+Caused by: java.sql.SQLNonTransientConnectionException: Socket fail to connect to mariadb. mariadb
+	at org.mariadb.jdbc.client.impl.ConnectionHelper.connectSocket(ConnectionHelper.java:131) ~[mariadb-java-client-3.5.4.jar:na]
+	at org.mariadb.jdbc.client.impl.StandardClient.<init>(StandardClient.java:125) ~[mariadb-java-client-3.5.4.jar:na]
+	at org.mariadb.jdbc.Driver.connect(Driver.java:75) ~[mariadb-java-client-3.5.4.jar:na]
+	at org.mariadb.jdbc.Driver.connect(Driver.java:104) ~[mariadb-java-client-3.5.4.jar:na]
+	at org.mariadb.jdbc.Driver.connect(Driver.java:29) ~[mariadb-java-client-3.5.4.jar:na]
+	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:144) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:368) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:205) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:488) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:576) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:97) ~[HikariCP-6.3.1.jar:na]
+	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111) ~[HikariCP-6.3.1.jar:na]
+	at org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection(JdbcUtils.java:59) ~[flyway-core-11.7.2.jar:na]
+	... 26 common frames omitted
+Caused by: java.net.UnknownHostException: mariadb
+	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567) ~[na:na]
+	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327) ~[na:na]
+	at java.base/java.net.Socket.connect(Socket.java:751) ~[na:na]
+	at org.mariadb.jdbc.client.impl.ConnectionHelper.connectSocket(ConnectionHelper.java:118) ~[mariadb-java-client-3.5.4.jar:na]
+	... 38 common frames omitted
+
+
+> Task :qiin-api:bootRun FAILED
+6 actionable tasks: 4 executed, 2 up-to-date

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/applied_reservation/GetAppliedReservationResponseDto.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/applied_reservation/GetAppliedReservationResponseDto.java
@@ -22,7 +22,7 @@ public class GetAppliedReservationResponseDto {
     private final String applicantName;
 
     // 예약 가능 여부
-    private final boolean reservable; // jacksonized에서 파악용 필드
+    private final Boolean isAvailable;
 
     // 응답 시 필수 x
     // 승인자
@@ -39,7 +39,7 @@ public class GetAppliedReservationResponseDto {
     private final Long version;
 
     public static GetAppliedReservationResponseDto fromRaw(
-            final RawAppliedReservationResponseDto raw, final boolean isReservable) {
+            final RawAppliedReservationResponseDto raw, final boolean isAvailable) {
         return GetAppliedReservationResponseDto.builder()
                 .assetName(raw.getAssetName())
                 .reservationId(raw.getReservationId())
@@ -48,7 +48,7 @@ public class GetAppliedReservationResponseDto {
                 .reservationStatus(
                         ReservationStatus.from(raw.getReservationStatus()).name())
                 .isApproved(raw.getIsApproved())
-                .reservable(isReservable)
+                .isAvailable(isAvailable)
                 .version(raw.getVersion())
                 .reason(raw.getReason())
                 .build();

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/raw/RawAppliedReservationResponseDto.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/raw/RawAppliedReservationResponseDto.java
@@ -1,5 +1,6 @@
 package com.beyond.qiin.domain.booking.dto.reservation.response.raw;
 
+import com.beyond.qiin.domain.inventory.enums.AssetStatus;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ public class RawAppliedReservationResponseDto {
 
     private final Long assetId;
     private final String assetName;
+    private final int assetStatus;
     private final Long reservationId;
     private final String applicantName;
     private final String respondentName;
@@ -19,4 +21,8 @@ public class RawAppliedReservationResponseDto {
     private final Long version;
     private final Instant startAt;
     private final Instant endAt;
+
+    public boolean isAssetAvailable() {
+        return assetStatus == AssetStatus.AVAILABLE.getCode();
+    }
 }

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/slot/RawReservationSlotResponseDto.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/dto/reservation/response/slot/RawReservationSlotResponseDto.java
@@ -1,0 +1,5 @@
+package com.beyond.qiin.domain.booking.dto.reservation.response.slot;
+
+import java.time.Instant;
+
+public record RawReservationSlotResponseDto(Long reservationId, Long assetId, Instant startAt) {}

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/entity/Reservation.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/entity/Reservation.java
@@ -199,10 +199,9 @@ public class Reservation extends BaseEntity {
     }
 
     public void changeSchedule(Instant startAt, Instant endAt) {
-        // pending일때 시간 변경 가능(승인전)
-        if (this.status != ReservationStatus.PENDING.getCode())
+        // pending, approved일때 시간 변경 가능(사용전)
+        if (this.status != ReservationStatus.PENDING.getCode() && this.status != ReservationStatus.APPROVED.getCode())
             throw new ReservationException(ReservationErrorCode.RESERVATION_STATUS_CHANGE_NOT_ALLOWED);
-        // TODO : time slot 제거, 변경 시각으로 다시 넣는 것을 시도
         this.startAt = startAt;
         this.endAt = endAt;
     }

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/repository/ReservationSlotJpaRepository.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/repository/ReservationSlotJpaRepository.java
@@ -1,8 +1,29 @@
 package com.beyond.qiin.domain.booking.repository;
 
+import com.beyond.qiin.domain.booking.dto.reservation.response.slot.RawReservationSlotResponseDto;
 import com.beyond.qiin.domain.booking.entity.ReservationSlot;
+import java.time.Instant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReservationSlotJpaRepository extends JpaRepository<ReservationSlot, Long> {
     void deleteByReservationId(Long reservationId);
+
+    // all slots that startAt, endAt
+    @Query(
+            """
+            SELECT new com.beyond.qiin.domain.booking.dto.reservation.response.slot.RawReservationSlotResponseDto(
+                rs.reservation.id,
+                rs.asset.id,
+                rs.startAt
+            )
+            FROM ReservationSlot rs
+            WHERE rs.asset.id IN :assetIds
+              AND rs.startAt >= :startAt
+              AND rs.startAt < :endAt
+            """)
+    List<RawReservationSlotResponseDto> findAllForReservability(
+            @Param("assetIds") List<Long> assetIds, @Param("startAt") Instant startAt, @Param("endAt") Instant endAt);
 }

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/repository/querydsl/AppliedReservationsQueryRepositoryImpl.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/repository/querydsl/AppliedReservationsQueryRepositoryImpl.java
@@ -84,6 +84,7 @@ public class AppliedReservationsQueryRepositoryImpl implements AppliedReservatio
                         RawAppliedReservationResponseDto.class,
                         asset.id,
                         asset.name,
+                        asset.status,
                         reservation.id,
                         applicant.userName,
                         respondent.userName,

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/command/ReservationCommandServiceImpl.java
@@ -185,6 +185,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         }
 
         reservation.reject(respondent, confirmReservationRequestDto.getReason()); // status rejected, reason 추가
+        reservationSlotManager.deleteSlots(reservationId);
 
         reservationWriter.save(reservation);
 
@@ -241,6 +242,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         Reservation reservation = reservationReader.getReservationById(reservationId);
         //        validateReservationCanceling(reservation); // 30분 전인 경우 허용
         reservation.cancel();
+        reservationSlotManager.deleteSlots(reservationId);
 
         reservationWriter.save(reservation);
 
@@ -264,8 +266,13 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         }
 
         if (updateReservationRequestDto.getStartAt() != null && updateReservationRequestDto.getEndAt() != null) {
+            ReservationStatus statusBeforeChange = reservation.getStatus();
+            reservationSlotManager.deleteSlots(reservationId);
             reservation.changeSchedule(
                     updateReservationRequestDto.getStartAt(), updateReservationRequestDto.getEndAt());
+            if (statusBeforeChange == ReservationStatus.APPROVED) {
+                reservationSlotManager.createSlots(reservation, reservation.getAsset());
+            }
         }
 
         // 수정 시 참여자들을 무조건 받는 구조 : id 없는 경우 -> 빈 배열일 때도 이전 추가된 참여들을 위해 삭제해야함
@@ -303,13 +310,14 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         reservation.softDeleteAll(userId); // 예약, 참여자 둘다 soft delete 처리
 
         // reservation slot 삭제
-        reservationSlotJpaRepository.deleteByReservationId(reservationId);
+        reservationSlotManager.deleteSlots(reservationId);
 
         reservationWriter.save(reservation);
     }
 
     // 하드 딜리트
     public void hardDeleteReservation(final Long reservationId) {
+        reservationSlotManager.deleteSlots(reservationId);
         reservationWriter.hardDelete(reservationId);
     }
 

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
@@ -123,14 +123,12 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
         // 예약 가능한지에 대해 포함해서 페이지 제공
         Page<GetAppliedReservationResponseDto> page = rawPage.map(raw -> {
-            boolean isAssetAvailable = assetQueryService.isAvailable(raw.getAssetId());
+            boolean isAssetAvailable = raw.isAssetAvailable();
 
             boolean isReservableTime = isReservationTimeAvailable(
                     raw.getReservationId(), raw.getAssetId(), raw.getStartAt(), raw.getEndAt());
 
-            boolean isReservable = isAssetAvailable && isReservableTime;
-
-            return GetAppliedReservationResponseDto.fromRaw(raw, isReservable);
+            return GetAppliedReservationResponseDto.fromRaw(raw, isReservableTime && isAssetAvailable);
         });
         return PageResponseDto.from(page);
     }

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/service/query/ReservationQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.beyond.qiin.domain.booking.dto.reservation.response.month_reservation
 import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawAppliedReservationResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawUserReservationResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.reservable_asset.ReservableAssetResponseDto;
+import com.beyond.qiin.domain.booking.dto.reservation.response.slot.RawReservationSlotResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.user_reservation.GetUserReservationResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.week_reservation.WeekReservationDailyResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.week_reservation.WeekReservationListResponseDto;
@@ -23,6 +24,7 @@ import com.beyond.qiin.domain.booking.entity.Reservation;
 import com.beyond.qiin.domain.booking.enums.ReservationStatus;
 import com.beyond.qiin.domain.booking.exception.ReservationErrorCode;
 import com.beyond.qiin.domain.booking.exception.ReservationException;
+import com.beyond.qiin.domain.booking.repository.ReservationSlotJpaRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.AppliedReservationsQueryRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.ReservationQueryRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.UserReservationsQueryRepository;
@@ -64,6 +66,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
     private final AppliedReservationsQueryRepository appliedReservationsQueryRepository;
     private final AssetQueryRepository assetQueryRepository;
     private final ReservationQueryRepository reservationQueryRepository;
+    private final ReservationSlotJpaRepository reservationSlotJpaRepository;
 
     // 예약 상세 조회 (api용)
     @Override
@@ -121,12 +124,14 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         Page<RawAppliedReservationResponseDto> rawPage =
                 appliedReservationsQueryRepository.search(appliedReservationSearchCriteria, pageable);
 
+        Map<Long, List<RawReservationSlotResponseDto>> slotsByAssetId = getReservationSlotsInBulk(rawPage.getContent());
+
         // 예약 가능한지에 대해 포함해서 페이지 제공
         Page<GetAppliedReservationResponseDto> page = rawPage.map(raw -> {
             boolean isAssetAvailable = raw.isAssetAvailable();
 
-            boolean isReservableTime = isReservationTimeAvailable(
-                    raw.getReservationId(), raw.getAssetId(), raw.getStartAt(), raw.getEndAt());
+            boolean isReservableTime = raw.getReservationStatus() == ReservationStatus.PENDING.getCode()
+                    && isReservationTimeAvailable(raw.getAssetId(), raw.getStartAt(), raw.getEndAt(), slotsByAssetId);
 
             return GetAppliedReservationResponseDto.fromRaw(raw, isReservableTime && isAssetAvailable);
         });
@@ -397,43 +402,47 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         return !(coveredStart.equals(dayStart) && coveredEnd.equals(dayEnd));
     }
 
-    // api x 비즈니스 메서드
-    private void validateReservationAvailability(
-            final Long reservationId, final Long assetId, final Instant startAt, final Instant endAt) {
-        if (!isReservationTimeAvailable(reservationId, assetId, startAt, endAt))
-            throw new ReservationException(ReservationErrorCode.RESERVATION_TIME_DUPLICATED);
-    }
-
     // test 가능하도록 package private 허용
     // 자원에 대한 예약 가능의 유무 -  비즈니스 책임이므로 command service로
     boolean isReservationTimeAvailable(
-            final Long reservationId, final Long assetId, final Instant startAt, final Instant endAt) {
+            final Long assetId,
+            final Instant startAt,
+            final Instant endAt,
+            final Map<Long, List<RawReservationSlotResponseDto>> slotsByAssetId) {
 
-        List<Reservation> reservations = reservationReader.getActiveReservationsByAssetId(assetId);
+        List<RawReservationSlotResponseDto> assetSlots = slotsByAssetId.getOrDefault(assetId, List.of());
 
-        for (Reservation reservation : reservations) {
+        return assetSlots.stream()
+                .noneMatch(slot ->
+                        !slot.startAt().isBefore(startAt) && slot.startAt().isBefore(endAt));
+    }
 
-            if (reservationId != null) { // 생성시는 null
-                if (reservation.getId().equals(reservationId)) {
-                    continue;
-                }
-            }
+    private Map<Long, List<RawReservationSlotResponseDto>> getReservationSlotsInBulk(
+            final List<RawAppliedReservationResponseDto> reservations) {
 
-            Instant existingStart = reservation.getStartAt();
-            Instant existingEnd = reservation.getEndAt();
-
-            // 딱 맞닿는 경우는 허용
-            if (startAt.equals(existingEnd) || endAt.equals(existingStart)) {
-                continue;
-            }
-
-            // 겹침 체크
-            boolean overlaps = startAt.isBefore(existingEnd) && endAt.isAfter(existingStart);
-
-            if (overlaps) return false;
+        if (reservations.isEmpty()) {
+            return Map.of();
         }
 
-        return true;
+        List<Long> assetIds = reservations.stream()
+                .map(RawAppliedReservationResponseDto::getAssetId)
+                .distinct()
+                .toList();
+
+        Instant minStartAt = reservations.stream()
+                .map(RawAppliedReservationResponseDto::getStartAt)
+                .min(Instant::compareTo)
+                .orElseThrow();
+
+        Instant maxEndAt = reservations.stream()
+                .map(RawAppliedReservationResponseDto::getEndAt)
+                .max(Instant::compareTo)
+                .orElseThrow();
+
+        List<RawReservationSlotResponseDto> slots =
+                reservationSlotJpaRepository.findAllForReservability(assetIds, minStartAt, maxEndAt);
+
+        return slots.stream().collect(Collectors.groupingBy(RawReservationSlotResponseDto::assetId));
     }
 
     private DateRange resolveSearchDateRange(GetAppliedReservationSearchCondition condition) {

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/support/ReservationSlotManager.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/booking/support/ReservationSlotManager.java
@@ -52,4 +52,14 @@ public class ReservationSlotManager {
             throw new ReservationException(ReservationErrorCode.RESERVATION_TIME_DUPLICATED);
         }
     }
+
+    public void deleteSlots(final Long reservationId) {
+        reservationSlotJpaRepository.deleteByReservationId(reservationId);
+        reservationSlotJpaRepository.flush();
+    }
+
+    public void recreateSlots(final Reservation reservation, final Asset asset) {
+        deleteSlots(reservation.getId());
+        createSlots(reservation, asset);
+    }
 }

--- a/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/inventory/entity/Asset.java
+++ b/qiin-be/qiin-api/src/main/java/com/beyond/qiin/domain/inventory/entity/Asset.java
@@ -5,24 +5,9 @@ import com.beyond.qiin.domain.inventory.dto.asset.request.CreateAssetRequestDto;
 import com.beyond.qiin.domain.inventory.dto.asset.request.UpdateAssetRequestDto;
 import com.beyond.qiin.domain.inventory.enums.AssetStatus;
 import com.beyond.qiin.domain.inventory.enums.AssetType;
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -54,7 +39,7 @@ public class Asset extends BaseEntity {
     private String image;
 
     @Column(name = "status", nullable = false)
-    private int status;
+    private int status; // 0 : disabled, 1 : available
 
     @Transient
     private AssetStatus assetStatus;

--- a/qiin-be/qiin-api/src/main/resources/application-dev.yml
+++ b/qiin-be/qiin-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   cache:
-    type: redis #none
+    type: none #redis
 
   config:
     activate:

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/ReservationControllerTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/ReservationControllerTest.java
@@ -531,7 +531,7 @@ public class ReservationControllerTest {
                 .respondentName("관리자")
                 .reservationStatus("PENDING")
                 .isApproved(false)
-                .isReservable(true)
+                .isAvailable(true)
                 .reason(null)
                 .version(1L)
                 .build();
@@ -557,6 +557,7 @@ public class ReservationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].reservationId").value(100L))
                 .andExpect(jsonPath("$.content[0].assetName").value("회의실 A"))
-                .andExpect(jsonPath("$.content[0].applicantName").value("홍길동"));
+                .andExpect(jsonPath("$.content[0].applicantName").value("홍길동"))
+                .andExpect(jsonPath("$.content[0].isAvailable").value(true));
     }
 }

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
@@ -1,50 +1,36 @@
 package com.beyond.qiin.domain.booking.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-import com.beyond.qiin.domain.booking.entity.Reservation;
-import com.beyond.qiin.domain.booking.support.ReservationReader;
+import com.beyond.qiin.domain.booking.dto.reservation.response.slot.RawReservationSlotResponseDto;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ReservationTimeValidationTest {
 
-    @Mock
-    ReservationReader reservationReader;
-
     @InjectMocks
     ReservationQueryServiceImpl reservationService;
 
-    private Reservation res(String start, String end, Long id) {
-        Reservation r = Reservation.builder()
-                .startAt(Instant.parse(start))
-                .endAt(Instant.parse(end))
-                .build();
-
-        ReflectionTestUtils.setField(r, "id", id);
-        return r;
+    private RawReservationSlotResponseDto slot(String start, Long id) {
+        return new RawReservationSlotResponseDto(id, 1L, Instant.parse(start));
     }
 
-    private boolean check(String start, String end, List<Reservation> existing) {
-        when(reservationReader.getActiveReservationsByAssetId(1L)).thenReturn(existing);
-
-        // TODO :
-        return reservationService.isReservationTimeAvailable(null, 1L, Instant.parse(start), Instant.parse(end));
+    private boolean check(String start, String end, List<RawReservationSlotResponseDto> existing) {
+        return reservationService.isReservationTimeAvailable(
+                1L, Instant.parse(start), Instant.parse(end), Map.of(1L, existing));
     }
 
     @DisplayName("완전 비겹침 - 왼쪽")
     @Test
     void left_non_overlap() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
         boolean ok = check("2025-01-03T07:00:00Z", "2025-01-03T08:00:00Z", existing);
 
@@ -54,7 +40,7 @@ class ReservationTimeValidationTest {
     @DisplayName("완전 비겹침 - 오른쪽")
     @Test
     void right_non_overlap() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
         boolean ok = check("2025-01-03T11:00:00Z", "2025-01-03T12:00:00Z", existing);
 
@@ -64,7 +50,7 @@ class ReservationTimeValidationTest {
     @DisplayName("시각이 겹치는 경우")
     @Test
     void touching_is_allowed() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
         boolean ok = check("2025-01-03T10:00:00Z", "2025-01-03T11:00:00Z", existing);
 
@@ -74,9 +60,9 @@ class ReservationTimeValidationTest {
     @DisplayName("부분 겹침 (왼쪽)")
     @Test
     void partial_overlap_left() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
-        boolean ok = check("2025-01-03T08:00:00Z", "2025-01-03T09:30:00Z", existing);
+        boolean ok = check("2025-01-03T08:00:00Z", "2025-01-03T10:00:00Z", existing);
 
         assertThat(ok).isFalse();
     }
@@ -84,7 +70,7 @@ class ReservationTimeValidationTest {
     @DisplayName("기존 전체를 감싸는 경우")
     @Test
     void new_includes_existing() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
         boolean ok = check("2025-01-03T08:00:00Z", "2025-01-03T12:00:00Z", existing);
 
@@ -94,9 +80,9 @@ class ReservationTimeValidationTest {
     @DisplayName("기존 안쪽에 완전히 포함되는 경우")
     @Test
     void new_inside_existing() {
-        List<Reservation> existing = List.of(res("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", 1L));
+        List<RawReservationSlotResponseDto> existing = List.of(slot("2025-01-03T09:00:00Z", 1L));
 
-        boolean ok = check("2025-01-03T09:30:00Z", "2025-01-03T09:45:00Z", existing);
+        boolean ok = check("2025-01-03T09:00:00Z", "2025-01-03T10:00:00Z", existing);
 
         assertThat(ok).isFalse();
     }

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/command/ReservationTimeValidationTest.java
@@ -1,4 +1,4 @@
-package com.beyond.qiin.domain.booking.service.command;
+package com.beyond.qiin.domain.booking.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -22,7 +22,7 @@ class ReservationTimeValidationTest {
     ReservationReader reservationReader;
 
     @InjectMocks
-    ReservationCommandServiceImpl reservationService;
+    ReservationQueryServiceImpl reservationService;
 
     private Reservation res(String start, String end, Long id) {
         Reservation r = Reservation.builder()

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsCacheTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsCacheTest.java
@@ -8,10 +8,17 @@ import com.beyond.qiin.common.dto.PageResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.request.search_condition.GetAppliedReservationSearchCondition;
 import com.beyond.qiin.domain.booking.dto.reservation.response.applied_reservation.GetAppliedReservationResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawAppliedReservationResponseDto;
+import com.beyond.qiin.domain.booking.repository.ReservationSlotJpaRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.AppliedReservationsQueryRepository;
+import com.beyond.qiin.domain.booking.repository.querydsl.ReservationQueryRepository;
+import com.beyond.qiin.domain.booking.repository.querydsl.UserReservationsQueryRepository;
+import com.beyond.qiin.domain.booking.support.ReservationReader;
 import com.beyond.qiin.domain.iam.entity.User;
 import com.beyond.qiin.domain.iam.support.user.UserReader;
+import com.beyond.qiin.domain.inventory.repository.querydsl.AssetQueryRepository;
 import com.beyond.qiin.domain.inventory.service.query.AssetQueryService;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,10 +26,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.*;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootTest
+@SpringBootTest(
+        classes = {
+            ReservationQueryServiceImpl.class,
+            com.beyond.qiin.domain.booking.support.AppliedReservationCachePolicy.class,
+            GetAppliedReservationsCacheTest.CacheTestConfig.class
+        })
 public class GetAppliedReservationsCacheTest {
 
     @Autowired
@@ -38,7 +54,31 @@ public class GetAppliedReservationsCacheTest {
     private UserReader userReader;
 
     @MockitoBean
+    private ReservationReader reservationReader;
+
+    @MockitoBean
     private AssetQueryService assetQueryService;
+
+    @MockitoBean
+    private UserReservationsQueryRepository userReservationsQueryRepository;
+
+    @MockitoBean
+    private AssetQueryRepository assetQueryRepository;
+
+    @MockitoBean
+    private ReservationQueryRepository reservationQueryRepository;
+
+    @MockitoBean
+    private ReservationSlotJpaRepository reservationSlotJpaRepository;
+
+    @Configuration
+    @EnableCaching
+    static class CacheTestConfig {
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("appliedReservations");
+        }
+    }
 
     @BeforeEach
     void setUp() {
@@ -62,7 +102,7 @@ public class GetAppliedReservationsCacheTest {
         condition.setStartDate(null);
         condition.setEndDate(null);
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         User mockUser = mock(User.class);
         given(userReader.findById(userId)).willReturn(mockUser);
@@ -70,12 +110,14 @@ public class GetAppliedReservationsCacheTest {
         RawAppliedReservationResponseDto rawDto = mock(RawAppliedReservationResponseDto.class);
         given(rawDto.getAssetId()).willReturn(100L);
         given(rawDto.getReservationId()).willReturn(200L);
-        given(rawDto.getStartAt()).willReturn(null);
-        given(rawDto.getEndAt()).willReturn(null);
+        given(rawDto.getStartAt()).willReturn(Instant.parse("2025-12-04T10:00:00Z"));
+        given(rawDto.getEndAt()).willReturn(Instant.parse("2025-12-04T12:00:00Z"));
 
         Page<RawAppliedReservationResponseDto> rawPage = new PageImpl<>(java.util.List.of(rawDto), pageable, 1);
 
         given(appliedReservationsQueryRepository.search(any(), any())).willReturn(rawPage);
+        given(reservationSlotJpaRepository.findAllForReservability(any(), any(), any()))
+                .willReturn(List.of());
         given(assetQueryService.isAvailable(any())).willReturn(true);
 
         // when

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsTest.java
@@ -9,6 +9,7 @@ import com.beyond.qiin.common.dto.PageResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.request.search_condition.GetAppliedReservationSearchCondition;
 import com.beyond.qiin.domain.booking.dto.reservation.response.applied_reservation.GetAppliedReservationResponseDto;
 import com.beyond.qiin.domain.booking.dto.reservation.response.raw.RawAppliedReservationResponseDto;
+import com.beyond.qiin.domain.booking.repository.ReservationSlotJpaRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.AppliedReservationsQueryRepository;
 import com.beyond.qiin.domain.booking.repository.querydsl.UserReservationsQueryRepository;
 import com.beyond.qiin.domain.booking.support.ReservationReader;
@@ -48,6 +49,9 @@ public class GetAppliedReservationsTest {
     @Mock
     private UserReservationsQueryRepository userReservationsQueryRepository;
 
+    @Mock
+    private ReservationSlotJpaRepository reservationSlotJpaRepository;
+
     @Test
     void getReservationApplies_returnsPagedDto() {
         Long userId = 1L;
@@ -68,7 +72,7 @@ public class GetAppliedReservationsTest {
                 1L,
                 "Alice",
                 "Bob",
-                1,
+                0,
                 true,
                 "Projector needed",
                 100L,
@@ -92,7 +96,11 @@ public class GetAppliedReservationsTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<RawAppliedReservationResponseDto> rawPage = new PageImpl<>(List.of(raw1, raw2), pageable, 2);
         when(appliedReservationsQueryRepository.search(any(), eq(pageable))).thenReturn(rawPage);
-        when(reservationReader.getActiveReservationsByAssetId(any())).thenReturn(List.of());
+        when(reservationSlotJpaRepository.findAllForReservability(
+                        eq(List.of(10L, 20L)),
+                        eq(Instant.parse("2025-12-04T10:00:00Z")),
+                        eq(Instant.parse("2025-12-04T15:00:00Z"))))
+                .thenReturn(List.of());
 
         // 실행
         PageResponseDto<GetAppliedReservationResponseDto> result =

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/GetAppliedReservationsTest.java
@@ -1,7 +1,8 @@
 package com.beyond.qiin.domain.booking.service.query;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.beyond.qiin.common.dto.PageResponseDto;
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -50,7 +53,8 @@ public class GetAppliedReservationsTest {
         Long userId = 1L;
 
         GetAppliedReservationSearchCondition condition = new GetAppliedReservationSearchCondition();
-        condition.setDate(LocalDate.of(2025, 12, 4));
+        condition.setStartDate(LocalDate.of(2025, 12, 4));
+        condition.setEndDate(LocalDate.of(2025, 12, 4));
 
         // Mock user
         User user = User.builder().userName("Alice").build();
@@ -60,6 +64,7 @@ public class GetAppliedReservationsTest {
         RawAppliedReservationResponseDto raw1 = new RawAppliedReservationResponseDto(
                 10L,
                 "Projector",
+                0,
                 1L,
                 "Alice",
                 "Bob",
@@ -73,6 +78,7 @@ public class GetAppliedReservationsTest {
         RawAppliedReservationResponseDto raw2 = new RawAppliedReservationResponseDto(
                 20L,
                 "Laptop",
+                1,
                 2L,
                 "Charlie",
                 "David",
@@ -83,13 +89,10 @@ public class GetAppliedReservationsTest {
                 Instant.parse("2025-12-04T13:00:00Z"),
                 Instant.parse("2025-12-04T15:00:00Z"));
 
-        List<RawAppliedReservationResponseDto> rawList = List.of(raw1, raw2);
-        when(appliedReservationsQueryRepository.search(condition)).thenReturn(rawList);
-
-        // Mock asset availability
-        when(assetQueryService.isAvailable(anyLong())).thenReturn(true);
-
         Pageable pageable = PageRequest.of(0, 10);
+        Page<RawAppliedReservationResponseDto> rawPage = new PageImpl<>(List.of(raw1, raw2), pageable, 2);
+        when(appliedReservationsQueryRepository.search(any(), eq(pageable))).thenReturn(rawPage);
+        when(reservationReader.getActiveReservationsByAssetId(any())).thenReturn(List.of());
 
         // 실행
         PageResponseDto<GetAppliedReservationResponseDto> result =
@@ -101,5 +104,7 @@ public class GetAppliedReservationsTest {
 
         assertEquals("Projector", result.getContent().get(0).getAssetName());
         assertEquals("Laptop", result.getContent().get(1).getAssetName());
+        assertEquals(true, result.getContent().get(0).getIsAvailable());
+        assertEquals(false, result.getContent().get(1).getIsAvailable());
     }
 }

--- a/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/UserReservationsTest.java
+++ b/qiin-be/qiin-api/src/test/java/com/beyond/qiin/domain/booking/service/query/UserReservationsTest.java
@@ -64,11 +64,7 @@ public class UserReservationsTest {
                 null, // actualStartAt
                 null, // actualEndAt
                 100L, // version
-                10L, // assetId
-                "Projector", // assetName
-                "Electronics", // categoryName
-                0, // assetType
-                1 // assetStatus
+                "Projector" // assetName
                 );
 
         RawUserReservationResponseDto raw2 = new RawUserReservationResponseDto(
@@ -80,11 +76,7 @@ public class UserReservationsTest {
                 null, // actualStartAt
                 null, // actualEndAt
                 101L, // version
-                20L, // assetId
-                "Laptop", // assetName
-                "Electronics", // categoryName
-                1, // assetType
-                1 // assetStatus
+                "Laptop" // assetName
                 );
 
         List<RawUserReservationResponseDto> rawList = List.of(raw1, raw2);

--- a/qiin-be/src/main/resources/application-dev.yml
+++ b/qiin-be/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   cache:
-    type: redis #none
+    type: none #redis
 
   config:
     activate:


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 신청 예약 목록 조회의 n + 1 문제 해결

## ✨ 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [X] 코드 리팩토링
- [ ] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> 예: `feat/이슈번호-도메인-기능`
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/42-refactor-applied-res

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#42 ]

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
- 명시적으로 원래 엔티티의 연관된 엔티티의 필드를 접근하는 n + 1 문제는 아니나 각 엔티티별로 연관된 엔티티의 필드, 관련 메서드 호출함에 따라 n + 1 문제로 봄
- asset status를 reservation paging 시 projection으로 함께 조회, reservation time available은 slot id를 bulk 조회해와 비교하는 형태로 개선
- 5 VU 환경에서 평균 응답시간은 **13.89초에서 75.5ms로 약 99.46% 감소**, 약 **184배의 성능 개선**을 확인
p95 응답시간은 **16.86초에서 137.9ms로 약 99.18% 감소**했고, 처리량은 **0.32 req/s에서 4.60 req/s로 약 14.4배 증가**
개선 전후 모두 HTTP 실패율 0% 유지
